### PR TITLE
ci: add conditional execution and concurrency group

### DIFF
--- a/.github/workflows/on_push_pr_main.yml
+++ b/.github/workflows/on_push_pr_main.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect_changes:
     name: Detect repository changes

--- a/.github/workflows/on_push_pr_main.yml
+++ b/.github/workflows/on_push_pr_main.yml
@@ -10,12 +10,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect_changes:
+    name: Detect repository changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          backend:
+            - 'backend/**'
+          frontend:
+            - 'front/**'
+
   lint_frontend:
     name: Lint frontend
+    needs: detect_changes
+    if: ${{ needs.detect_changes.outputs.frontend == 'true' }}
     uses: ./.github/workflows/flow_front_lint.yml
 
   lint_backend:
     name: Lint backend
+    needs: detect_changes
+    if: ${{ needs.detect_changes.outputs.backend == 'true' }}
     uses: ./.github/workflows/flow_backend_lint.yml
 
   build_api_gateway:


### PR DESCRIPTION
This updates the CI to detect directories that changed and run the appropriate jobs (e.g., if you update the frontend, only the CI jobs pertaining to the frontend will run).

This also adds a concurrency group to avoid running the pipeline if a newer ref is available.

Those changes only applies to the "Push & PR" pipeline. The "Semver tag" pipeline remains unchanged.