### PR TITLE
chore(backend): move Gradle group and version definitions

### DIFF
--- a/backend/api_gateway/build.gradle.kts
+++ b/backend/api_gateway/build.gradle.kts
@@ -9,9 +9,6 @@ plugins {
     kotlin("plugin.jpa")
 }
 
-group = "com.linkedout"
-version = "1.0.0-SNAPSHOT"
-
 java {
     sourceCompatibility = JavaVersion.VERSION_17
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,4 @@
+allprojects {
+    group = "com.linkedout"
+    version = "1.0.0-SNAPSHOT"
+}

--- a/backend/common/build.gradle.kts
+++ b/backend/common/build.gradle.kts
@@ -11,9 +11,6 @@ plugins {
     kotlin("plugin.jpa")
 }
 
-group = "com.linkedout"
-version = "1.0.0-SNAPSHOT"
-
 java {
     sourceCompatibility = JavaVersion.VERSION_17
 }

--- a/backend/jobs/build.gradle.kts
+++ b/backend/jobs/build.gradle.kts
@@ -9,9 +9,6 @@ plugins {
     kotlin("plugin.jpa")
 }
 
-group = "com.linkedout"
-version = "1.0.0-SNAPSHOT"
-
 java {
     sourceCompatibility = JavaVersion.VERSION_17
 }

--- a/backend/protobuf/build.gradle.kts
+++ b/backend/protobuf/build.gradle.kts
@@ -5,9 +5,6 @@ plugins {
     kotlin("jvm")
 }
 
-group = "com.linkedout"
-version = "1.0.0-SNAPSHOT"
-
 java {
     sourceCompatibility = JavaVersion.VERSION_17
 }


### PR DESCRIPTION
This moves out the `group` and `version` properties setting from the individual microservices to the global `build.gradle.kts` file.