### PR TITLE
feat(messaging): implement findOneUserMessageChannel and findAllUserMessageChannels

### DIFF
--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
@@ -1,0 +1,19 @@
+package com.linkedout.backend.controller
+
+import com.linkedout.backend.model.MessageChannel
+import com.linkedout.backend.service.MessageChannelsService
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Flux
+import java.security.Principal
+
+@RestController
+@RequestMapping("/api/v1/messaging")
+class MessagingController(private val messageChannelsService: MessageChannelsService) {
+    @GetMapping
+    open fun getMessageChannelsOfUser(request: ServerHttpRequest, principal: Principal): Flux<MessageChannel> {
+        return messageChannelsService.findAllChannelsOfUser(request.id, principal.name)
+    }
+}

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
@@ -4,9 +4,11 @@ import com.linkedout.backend.model.MessageChannel
 import com.linkedout.backend.service.MessageChannelsService
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.security.Principal
 
 @RestController
@@ -15,5 +17,14 @@ class MessagingController(private val messageChannelsService: MessageChannelsSer
     @GetMapping
     open fun getMessageChannelsOfUser(request: ServerHttpRequest, principal: Principal): Flux<MessageChannel> {
         return messageChannelsService.findAllChannelsOfUser(request.id, principal.name)
+    }
+
+    @GetMapping("/{channelId}")
+    open fun getMessageChannelOfUser(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @PathVariable channelId: String
+    ): Mono<MessageChannel> {
+        return messageChannelsService.findOneChannelOfUser(request.id, principal.name, channelId)
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/model/Employer.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/model/Employer.kt
@@ -1,0 +1,9 @@
+package com.linkedout.backend.model
+
+data class Employer(
+    val id: String,
+    val firstName: String,
+    val lastName: String,
+    val picture: String,
+    val phone: String
+)

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/model/MessageChannel.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/model/MessageChannel.kt
@@ -1,0 +1,7 @@
+package com.linkedout.backend.model
+
+data class MessageChannel(
+    val id: String,
+    val employer: Employer,
+    val lastMessage: String
+)

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobCategoryService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobCategoryService.kt
@@ -18,7 +18,7 @@ class JobCategoryService(private val natsService: NatsService, @Value("\${app.se
             throw Exception("Invalid response")
         }
 
-        val getJobCategoriesResponse = response.getGetJobCategoriesResponse()
+        val getJobCategoriesResponse = response.getJobCategoriesResponse
 
         return Flux.fromIterable(getJobCategoriesResponse.categoriesList)
             .map { jobCategory ->

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobService.kt
@@ -20,7 +20,7 @@ class JobService(private val natsService: NatsService, @Value("\${app.services.j
             throw Exception("Invalid response")
         }
 
-        val getJobsResponse = response.getGetJobsResponse()
+        val getJobsResponse = response.getJobsResponse
 
         return Flux.fromIterable(getJobsResponse.jobsList)
             .map { job ->
@@ -34,7 +34,6 @@ class JobService(private val natsService: NatsService, @Value("\${app.services.j
             .setGetJobRequest(
                 GetJobRequest.newBuilder()
                     .setId(id)
-                    .build()
             )
             .build()
 
@@ -45,7 +44,7 @@ class JobService(private val natsService: NatsService, @Value("\${app.services.j
             throw Exception("Invalid response")
         }
 
-        val getJobResponse = response.getGetJobResponse()
+        val getJobResponse = response.getJobResponse
         return Mono.just(Job(getJobResponse.job.id, getJobResponse.job.title, getJobResponse.job.category))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
@@ -1,0 +1,38 @@
+package com.linkedout.backend.service
+
+import com.linkedout.backend.model.Employer
+import com.linkedout.backend.model.MessageChannel
+import com.linkedout.common.service.NatsService
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.proto.services.Messaging.GetUserMessageChannelsRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+
+@Service
+class MessageChannelsService(private val natsService: NatsService, @Value("\${app.services.messageChannels.subjects.findAllOfUser}") private val findAllOfUsersSubject: String) {
+    fun findAllChannelsOfUser(requestId: String, userId: String): Flux<MessageChannel> {
+        // Request message channels from the messaging service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setGetUserMessageChannelsRequest(
+                GetUserMessageChannelsRequest.newBuilder()
+                    .setUserId(userId)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(findAllOfUsersSubject, request)
+
+        // Handle the response
+        if (!response.hasGetUserMessageChannelsResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val getUserMessageChannelsResponse = response.getUserMessageChannelsResponse
+
+        return Flux.fromIterable(getUserMessageChannelsResponse.messageChannelsList)
+            .map { messageChannel ->
+                // TODO: Get the employer from the employer service
+                MessageChannel(messageChannel.id, Employer("<TODO>", "<TODO>", "<TODO>", "<TODO>", "<TODO>"), messageChannel.lastMessage)
+            }
+    }
+}

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
@@ -4,13 +4,19 @@ import com.linkedout.backend.model.Employer
 import com.linkedout.backend.model.MessageChannel
 import com.linkedout.common.service.NatsService
 import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.proto.services.Messaging
 import com.linkedout.proto.services.Messaging.GetUserMessageChannelsRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Service
-class MessageChannelsService(private val natsService: NatsService, @Value("\${app.services.messageChannels.subjects.findAllOfUser}") private val findAllOfUsersSubject: String) {
+class MessageChannelsService(
+    private val natsService: NatsService,
+    @Value("\${app.services.messageChannels.subjects.findAllOfUser}") private val findAllOfUsersSubject: String,
+    @Value("\${app.services.messageChannels.subjects.findOneOfUser}") private val findOneOfUserSubject: String
+) {
     fun findAllChannelsOfUser(requestId: String, userId: String): Flux<MessageChannel> {
         // Request message channels from the messaging service
         val request = RequestResponseFactory.newRequest(requestId)
@@ -32,7 +38,39 @@ class MessageChannelsService(private val natsService: NatsService, @Value("\${ap
         return Flux.fromIterable(getUserMessageChannelsResponse.messageChannelsList)
             .map { messageChannel ->
                 // TODO: Get the employer from the employer service
-                MessageChannel(messageChannel.id, Employer("<TODO>", "<TODO>", "<TODO>", "<TODO>", "<TODO>"), messageChannel.lastMessage)
+                MessageChannel(
+                    messageChannel.id,
+                    Employer("<TODO>", "<TODO>", "<TODO>", "<TODO>", "<TODO>"),
+                    messageChannel.lastMessage
+                )
             }
+    }
+
+    fun findOneChannelOfUser(requestId: String, userId: String, channelId: String): Mono<MessageChannel> {
+        // Request message channel from the messaging service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setGetUserMessageChannelByIdRequest(
+                Messaging.GetUserMessageChannelByIdRequest.newBuilder()
+                    .setUserId(userId)
+                    .setMessageChannelId(channelId)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(findOneOfUserSubject, request)
+
+        // Handle the response
+        if (!response.hasGetUserMessageChannelByIdResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val getUserMessageChannelByIdResponse = response.getUserMessageChannelByIdResponse
+        // TODO: Get the employer from the employer service
+        return Mono.just(
+            MessageChannel(
+                getUserMessageChannelByIdResponse.messageChannel.id,
+                Employer("<TODO>", "<TODO>", "<TODO>", "<TODO>", "<TODO>"),
+                getUserMessageChannelByIdResponse.messageChannel.lastMessage
+            )
+        )
     }
 }

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -22,3 +22,6 @@ app:
     jobCategories:
       subjects:
         findAll: jobs.findAllCategories
+    messageChannels:
+      subjects:
+        findAllOfUser: messaging.findAllUserMessageChannels

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -25,3 +25,4 @@ app:
     messageChannels:
       subjects:
         findAllOfUser: messaging.findAllUserMessageChannels
+        findOneOfUser: messaging.findOneUserMessageChannel

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -24,5 +24,5 @@ app:
         findAll: jobs.findAllCategories
     messageChannels:
       subjects:
-        findAllOfUser: messaging.findAllUserMessageChannels
-        findOneOfUser: messaging.findOneUserMessageChannel
+        findAllOfUser: messaging.findAllChannelsOfUser
+        findOneOfUser: messaging.findOneChannelOfUser

--- a/backend/jobs/src/main/kotlin/com/linkedout/jobs/function/jobs/GetJob.kt
+++ b/backend/jobs/src/main/kotlin/com/linkedout/jobs/function/jobs/GetJob.kt
@@ -8,14 +8,14 @@ import com.linkedout.proto.models.JobOuterClass
 import com.linkedout.proto.services.Jobs
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import java.util.*
+import java.util.UUID
 import java.util.function.Function
 
 @Component
 class GetJob(private val jobService: JobService) : Function<Request, Response> {
     override fun apply(t: Request): Response {
         // Get the job from the database
-        val responseMono = jobService.findOneWithCategory(UUID.fromString(t.getGetJobRequest().id))
+        val responseMono = jobService.findOneWithCategory(UUID.fromString(t.getJobRequest.id))
             .map { job ->
                 JobOuterClass.Job.newBuilder()
                     .setId(job.id)

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/MessagingApplication.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/MessagingApplication.kt
@@ -1,4 +1,4 @@
-package com.linkedout.jobs
+package com.linkedout.messaging
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUser.kt
@@ -1,4 +1,4 @@
-package com.linkedout.messaging.function.messaging
+package com.linkedout.messaging.function.messageChannels
 
 import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.messaging.service.MessageChannelService
@@ -12,7 +12,7 @@ import java.util.*
 import java.util.function.Function
 
 @Component
-class FindOneUserMessageChannel(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
+class GetChannelOfUser(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
     override fun apply(t: Request): Response {
         // Get the message channel from the database
         val request = t.getUserMessageChannelByIdRequest

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelsOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelsOfUser.kt
@@ -1,4 +1,4 @@
-package com.linkedout.messaging.function.messaging
+package com.linkedout.messaging.function.messageChannels
 
 import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.messaging.service.MessageChannelService
@@ -11,7 +11,7 @@ import java.util.UUID
 import java.util.function.Function
 
 @Component
-class FindAllUserMessageChannels(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
+class GetChannelsOfUser(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
     override fun apply(t: Request): Response {
         // Get the message channels from the database
         val responseMono = messageChannelService.findAllWithSeasonworkerId(UUID.fromString(t.getUserMessageChannelsRequest.userId))

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messaging/FindAllUserMessageChannels.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messaging/FindAllUserMessageChannels.kt
@@ -1,0 +1,48 @@
+package com.linkedout.messaging.function.messaging
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.messaging.service.MessageChannelService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.MessageChannelOuterClass.MessageChannel
+import com.linkedout.proto.services.Messaging.GetUserMessageChannelsResponse
+import org.springframework.stereotype.Component
+import java.util.UUID
+import java.util.function.Function
+
+@Component
+class FindAllUserMessageChannels(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Get the message channels from the database
+        val responseMono = messageChannelService.findAllWithSeasonworkerId(UUID.fromString(t.getUserMessageChannelsRequest.userId))
+            .map { messageChannel ->
+                // TODO: Get the last message
+                MessageChannel.newBuilder()
+                    .setId(messageChannel.id.toString())
+                    .setEmployerId(messageChannel.employerId.toString())
+                    .setLastMessage("<TODO>")
+                    .build()
+            }
+            .reduce(GetUserMessageChannelsResponse.newBuilder()) { builder, messageChannel ->
+                builder.addMessageChannels(messageChannel)
+                builder
+            }
+            .map { builder ->
+                builder.build()
+            }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newSuccessfulResponse()
+                .setGetUserMessageChannelsResponse(GetUserMessageChannelsResponse.getDefaultInstance())
+                .build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetUserMessageChannelsResponse(response)
+            .build()
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messaging/FindOneUserMessageChannel.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messaging/FindOneUserMessageChannel.kt
@@ -1,0 +1,46 @@
+package com.linkedout.messaging.function.messaging
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.messaging.service.MessageChannelService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.MessageChannelOuterClass
+import com.linkedout.proto.services.Messaging.GetUserMessageChannelByIdResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.function.Function
+
+@Component
+class FindOneUserMessageChannel(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Get the message channel from the database
+        val request = t.getUserMessageChannelByIdRequest
+        val responseMono = messageChannelService.findOneWithSeasonworkerId(UUID.fromString(request.userId), UUID.fromString(request.messageChannelId))
+            .map { messageChannel ->
+                // TODO: Get the last message
+                MessageChannelOuterClass.MessageChannel.newBuilder()
+                    .setId(messageChannel.id.toString())
+                    .setEmployerId(messageChannel.employerId.toString())
+                    .setLastMessage("<TODO>")
+                    .build()
+            }
+            .map { messageChannel ->
+                GetUserMessageChannelByIdResponse.newBuilder()
+                    .setMessageChannel(messageChannel)
+                    .build()
+            }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Message channel not found", HttpStatus.NOT_FOUND).build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetUserMessageChannelByIdResponse(response)
+            .build()
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/MessageChannel.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/MessageChannel.kt
@@ -1,0 +1,16 @@
+package com.linkedout.messaging.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("messagechannel")
+data class MessageChannel(
+    @Id
+    val id: UUID,
+    @Column("seasonworkerid")
+    val seasonworkerId: UUID,
+    @Column("employerid")
+    val employerId: UUID
+)

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
@@ -1,0 +1,17 @@
+package com.linkedout.messaging.repository
+
+import com.linkedout.messaging.model.MessageChannel
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+import java.util.UUID
+
+interface MessageChannelRepository : ReactiveCrudRepository<MessageChannel, UUID> {
+    @Query(
+        """
+        SELECT * FROM messagechannel
+        WHERE seasonworkerid = :seasonworkerId
+    """
+    )
+    fun findAllWithSeasonworkerId(seasonworkerId: UUID): Flux<MessageChannel>
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
@@ -4,6 +4,7 @@ import com.linkedout.messaging.model.MessageChannel
 import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.util.UUID
 
 interface MessageChannelRepository : ReactiveCrudRepository<MessageChannel, UUID> {
@@ -14,4 +15,13 @@ interface MessageChannelRepository : ReactiveCrudRepository<MessageChannel, UUID
     """
     )
     fun findAllWithSeasonworkerId(seasonworkerId: UUID): Flux<MessageChannel>
+
+    @Query(
+        """
+        SELECT * FROM messagechannel
+        WHERE seasonworkerid = :seasonworkerId
+        AND id = :messageChannelId
+    """
+    )
+    fun findOneWithSeasonworkerId(seasonworkerId: UUID, messageChannelId: UUID): Mono<MessageChannel>
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
@@ -1,0 +1,14 @@
+package com.linkedout.messaging.service
+
+import com.linkedout.messaging.model.MessageChannel
+import com.linkedout.messaging.repository.MessageChannelRepository
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import java.util.UUID
+
+@Service
+class MessageChannelService(private val messageChannelRepository: MessageChannelRepository) {
+    fun findAllWithSeasonworkerId(seasonworkerId: UUID): Flux<MessageChannel> {
+        return messageChannelRepository.findAllWithSeasonworkerId(seasonworkerId)
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
@@ -4,11 +4,16 @@ import com.linkedout.messaging.model.MessageChannel
 import com.linkedout.messaging.repository.MessageChannelRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.util.UUID
 
 @Service
 class MessageChannelService(private val messageChannelRepository: MessageChannelRepository) {
     fun findAllWithSeasonworkerId(seasonworkerId: UUID): Flux<MessageChannel> {
         return messageChannelRepository.findAllWithSeasonworkerId(seasonworkerId)
+    }
+
+    fun findOneWithSeasonworkerId(seasonworkerId: UUID, messageChannelId: UUID): Mono<MessageChannel> {
+        return messageChannelRepository.findOneWithSeasonworkerId(seasonworkerId, messageChannelId)
     }
 }

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=findAllUserMessageChannels
+spring.cloud.function.definition=findAllUserMessageChannels;findOneUserMessageChannel
 
 spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.destination=messaging.findAllUserMessageChannels
 spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.group=messagingSvc
@@ -8,5 +8,14 @@ spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.destination=
 spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.group=messagingSvc
 spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.binder=nats
 spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.destination=messaging.findOneUserMessageChannel
+spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.group=messagingSvc
+spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.binder=nats
+spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.destination=
+spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.group=messagingSvc
+spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.binder=nats
+spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,1 +1,12 @@
+spring.cloud.function.definition=findAllUserMessageChannels
+
+spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.destination=messaging.findAllUserMessageChannels
+spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.group=messagingSvc
+spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.binder=nats
+spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.destination=
+spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.group=messagingSvc
+spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.binder=nats
+spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.content-type=application/vnd.linkedout.proto-response
+
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,21 +1,21 @@
-spring.cloud.function.definition=findAllUserMessageChannels;findOneUserMessageChannel
+spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser
 
-spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.destination=messaging.findAllUserMessageChannels
-spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.group=messagingSvc
-spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.binder=nats
-spring.cloud.stream.bindings.findAllUserMessageChannels-in-0.content-type=application/vnd.linkedout.proto-request
-spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.destination=
-spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.group=messagingSvc
-spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.binder=nats
-spring.cloud.stream.bindings.findAllUserMessageChannels-out-0.content-type=application/vnd.linkedout.proto-response
+spring.cloud.stream.bindings.getChannelsOfUser-in-0.destination=messaging.findAllChannelsOfUser
+spring.cloud.stream.bindings.getChannelsOfUser-in-0.group=messagingSvc
+spring.cloud.stream.bindings.getChannelsOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.getChannelsOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getChannelsOfUser-out-0.destination=
+spring.cloud.stream.bindings.getChannelsOfUser-out-0.group=messagingSvc
+spring.cloud.stream.bindings.getChannelsOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.getChannelsOfUser-out-0.content-type=application/vnd.linkedout.proto-response
 
-spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.destination=messaging.findOneUserMessageChannel
-spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.group=messagingSvc
-spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.binder=nats
-spring.cloud.stream.bindings.findOneUserMessageChannel-in-0.content-type=application/vnd.linkedout.proto-request
-spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.destination=
-spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.group=messagingSvc
-spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.binder=nats
-spring.cloud.stream.bindings.findOneUserMessageChannel-out-0.content-type=application/vnd.linkedout.proto-response
+spring.cloud.stream.bindings.getChannelOfUser-in-0.destination=messaging.findOneChannelOfUser
+spring.cloud.stream.bindings.getChannelOfUser-in-0.group=messagingSvc
+spring.cloud.stream.bindings.getChannelOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.getChannelOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getChannelOfUser-out-0.destination=
+spring.cloud.stream.bindings.getChannelOfUser-out-0.group=messagingSvc
+spring.cloud.stream.bindings.getChannelOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.getChannelOfUser-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
+++ b/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
@@ -1,0 +1,5 @@
+CREATE TABLE MessageChannel (
+                             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                             seasonworkerId UUID NOT NULL,
+                             employerId UUID NOT NULL
+);

--- a/backend/protobuf/src/main/proto/models/messageChannel.proto
+++ b/backend/protobuf/src/main/proto/models/messageChannel.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package com.linkedout.proto.models;
+
+message MessageChannel {
+  string id = 1;
+  string employer_id = 2;
+  string last_message = 3;
+}

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package com.linkedout.proto;
 
 import "services/jobs.proto";
+import "services/messaging.proto";
 
 // Message that contains a generic request
 message Request {
@@ -11,5 +12,6 @@ message Request {
     services.GetJobsRequest get_jobs_request = 2;
     services.GetJobRequest get_job_request = 3;
     services.GetJobCategoriesRequest get_job_categories_request = 4;
+    services.GetUserMessageChannelsRequest get_user_message_channels_request = 5;
   }
 }

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -13,5 +13,6 @@ message Request {
     services.GetJobRequest get_job_request = 3;
     services.GetJobCategoriesRequest get_job_categories_request = 4;
     services.GetUserMessageChannelsRequest get_user_message_channels_request = 5;
+    services.GetUserMessageChannelByIdRequest get_user_message_channel_by_id_request = 6;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -19,5 +19,6 @@ message Response {
     services.GetJobResponse get_job_response = 4;
     services.GetJobCategoriesResponse get_job_categories_response = 5;
     services.GetUserMessageChannelsResponse get_user_message_channels_response = 6;
+    services.GetUserMessageChannelByIdResponse get_user_message_channel_by_id_response = 7;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package com.linkedout.proto;
 
 import "services/jobs.proto";
+import "services/messaging.proto";
 
 // Message that contains a generic response
 message Error {
@@ -17,5 +18,6 @@ message Response {
     services.GetJobsResponse get_jobs_response = 3;
     services.GetJobResponse get_job_response = 4;
     services.GetJobCategoriesResponse get_job_categories_response = 5;
+    services.GetUserMessageChannelsResponse get_user_message_channels_response = 6;
   }
 }

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package com.linkedout.proto.services;
+
+import "models/messageChannel.proto";
+
+// Get message channels of a user
+message GetUserMessageChannelsRequest {
+    string userId = 1;
+}
+
+message GetUserMessageChannelsResponse {
+    repeated models.MessageChannel messageChannels = 1;
+}

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -11,3 +11,13 @@ message GetUserMessageChannelsRequest {
 message GetUserMessageChannelsResponse {
     repeated models.MessageChannel messageChannels = 1;
 }
+
+// Get a message channel of a user by id
+message GetUserMessageChannelByIdRequest {
+    string userId = 1;
+    string messageChannelId = 2;
+}
+
+message GetUserMessageChannelByIdResponse {
+    models.MessageChannel messageChannel = 1;
+}


### PR DESCRIPTION
This implements the methods in the messaging service to get a single message channel and all message channels of a user through the message broker.

The corresponding API gateway routes were also implemented for the currently logged-in user.

## Other changes

Explicit calls to some getters were removed.