### PR TITLE
feat(backend): bootstrap employer service and implement findOne

### DIFF
--- a/.github/workflows/on_push_pr_main.yml
+++ b/.github/workflows/on_push_pr_main.yml
@@ -50,7 +50,7 @@ jobs:
     uses: ./.github/workflows/flow_backend_build_push.yml
     strategy:
       matrix:
-        service: [api_gateway, jobs, messaging]
+        service: [api_gateway, jobs, messaging, employer]
     with:
       service-name: ${{ matrix.service }}
       push-image: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/on_semver_tag.yml
+++ b/.github/workflows/on_semver_tag.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/flow_backend_build_push.yml
     strategy:
       matrix:
-        service: [api_gateway, jobs, messaging]
+        service: [api_gateway, jobs, messaging, employer]
     with:
       service-name: ${{ matrix.service }}
       push-image: ${{ github.event_name != 'pull_request' }}

--- a/backend/employer/build.gradle.kts
+++ b/backend/employer/build.gradle.kts
@@ -1,0 +1,51 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+    id("org.jlleitschuh.gradle.ktlint")
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    kotlin("plugin.jpa")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":common"))
+    implementation(project(":protobuf"))
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework:spring-jdbc")
+    implementation("org.springframework.cloud:spring-cloud-stream:4.0.4")
+    implementation("io.nats:jnats:2.17.1")
+    implementation("io.nats:nats-spring:0.5.6")
+    implementation("io.nats:nats-spring-cloud-stream-binder:0.5.3")
+    implementation("org.flywaydb:flyway-core:9.22.3")
+    implementation("org.postgresql:r2dbc-postgresql:1.0.2.RELEASE")
+    implementation("jakarta.validation:jakarta.validation-api:3.0.2")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.20")
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    runtimeOnly("org.postgresql:postgresql")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.cloud:spring-cloud-stream-test-binder:4.0.4")
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs += "-Xjsr305=strict"
+        jvmTarget = "17"
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/EmployerApplication.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/EmployerApplication.kt
@@ -1,0 +1,11 @@
+package com.linkedout.employer
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication(scanBasePackages = ["com.linkedout"])
+class EmployerApplication
+
+fun main(args: Array<String>) {
+    runApplication<EmployerApplication>(*args)
+}

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/function/employer/GetEmployer.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/function/employer/GetEmployer.kt
@@ -1,0 +1,46 @@
+package com.linkedout.employer.function.employer
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.employer.service.EmployerService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.EmployerOuterClass
+import com.linkedout.proto.services.Employer.GetEmployerResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import java.util.UUID
+import java.util.function.Function
+
+@Component
+class GetEmployer(private val employerService: EmployerService) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Get the employer from the database
+        val responseMono = employerService.findOne(UUID.fromString(t.getEmployerRequest.id))
+            .map { employer ->
+                EmployerOuterClass.Employer.newBuilder()
+                    .setId(employer.id.toString())
+                    .setFirstName(employer.firstName)
+                    .setLastName(employer.lastName)
+                    .setPicture(employer.picture)
+                    .setPhone(employer.phone)
+                    .build()
+            }
+            .map { employer ->
+                GetEmployerResponse.newBuilder()
+                    .setEmployer(employer)
+                    .build()
+            }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Employer not found", HttpStatus.NOT_FOUND).build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetEmployerResponse(response)
+            .build()
+    }
+}

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/model/Employer.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/model/Employer.kt
@@ -1,0 +1,18 @@
+package com.linkedout.employer.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("employer")
+data class Employer(
+    @Id
+    val id: UUID,
+    @Column("firstname")
+    val firstName: String,
+    @Column("lastname")
+    val lastName: String,
+    val picture: String,
+    val phone: String
+)

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/repository/EmployerRepository.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/repository/EmployerRepository.kt
@@ -1,0 +1,7 @@
+package com.linkedout.employer.repository
+
+import com.linkedout.employer.model.Employer
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import java.util.UUID
+
+interface EmployerRepository : ReactiveCrudRepository<Employer, UUID>

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/service/EmployerService.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/service/EmployerService.kt
@@ -1,0 +1,14 @@
+package com.linkedout.employer.service
+
+import com.linkedout.employer.model.Employer
+import com.linkedout.employer.repository.EmployerRepository
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+@Service
+class EmployerService(private val employerRepository: EmployerRepository) {
+    fun findOne(id: UUID): Mono<Employer> {
+        return employerRepository.findById(id)
+    }
+}

--- a/backend/employer/src/main/resources/application.properties
+++ b/backend/employer/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+nats.spring.server=nats://localhost:4222

--- a/backend/employer/src/main/resources/application.properties
+++ b/backend/employer/src/main/resources/application.properties
@@ -1,1 +1,12 @@
+spring.cloud.function.definition=getEmployer
+
+spring.cloud.stream.bindings.getEmployer-in-0.destination=employer.findOne
+spring.cloud.stream.bindings.getEmployer-in-0.group=employerSvc
+spring.cloud.stream.bindings.getEmployer-in-0.binder=nats
+spring.cloud.stream.bindings.getEmployer-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getEmployer-out-0.destination=
+spring.cloud.stream.bindings.getEmployer-out-0.group=employerSvc
+spring.cloud.stream.bindings.getEmployer-out-0.binder=nats
+spring.cloud.stream.bindings.getEmployer-out-0.content-type=application/vnd.linkedout.proto-response
+
 nats.spring.server=nats://localhost:4222

--- a/backend/employer/src/main/resources/application.yml
+++ b/backend/employer/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://localhost:5432
+    username: employer
+    password: employer
+
+  flyway:
+    url: jdbc:postgresql://localhost:5432/employer
+    user: employer
+    password: employer
+
+server:
+  port: 8083

--- a/backend/employer/src/main/resources/db/migration/V1__initial_state.sql
+++ b/backend/employer/src/main/resources/db/migration/V1__initial_state.sql
@@ -1,0 +1,14 @@
+CREATE TABLE Employer (
+                             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                             firstName VARCHAR(64) NOT NULL,
+                             lastName VARCHAR(64) NOT NULL,
+                             picture VARCHAR(1024) NOT NULL,
+                             phone VARCHAR(20) NOT NULL
+);
+
+INSERT INTO Employer(id, firstName, lastName, picture, phone)
+VALUES
+    ('c80f53f4-0a33-4fe3-bf7f-a755c6e2235b', 'Nicolas', 'Sarkozy', 'https://upload.wikimedia.org/wikipedia/commons/c/ca/Flickr_-_europeanpeoplesparty_-_EPP_Summit_October_2010_(105)-(cropped).jpg', '0677096463'),
+    ('0dc07c97-fc40-4ac2-a9f6-0b0bbbe6057e', 'François', 'Hollande', 'https://peopleauquotidien.com/wp-content/uploads/2022/12/JTA19T-1-e1670495723208.jpg', '0632789456'),
+    ('8102b0f0-c03c-4f66-bd99-a2522625d11c', 'John', 'Cena', 'https://i.pinimg.com/736x/2d/8d/dd/2d8ddd5b89a7e067c2d3404773549a4d.jpg', '0742569874'),
+    ('4d40844c-4db9-45d3-bffd-18804411a69c', 'Noé', 'Tarbouret', 'https://vectorseek.com/wp-content/uploads/2023/03/Golang-Gopher-Logo-Vector.jpg', '0647932568');

--- a/backend/employer/src/test/kotlin/com/linkedout/employer/EmployerApplicationTests.kt
+++ b/backend/employer/src/test/kotlin/com/linkedout/employer/EmployerApplicationTests.kt
@@ -1,0 +1,11 @@
+package com.linkedout.employer
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class EmployerApplicationTests {
+    @Test
+    fun contextLoads() {
+    }
+}

--- a/backend/protobuf/src/main/proto/models/employer.proto
+++ b/backend/protobuf/src/main/proto/models/employer.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package com.linkedout.proto.models;
+
+message Employer {
+  string id = 1;
+  string firstName = 2;
+  string lastName = 3;
+  string picture = 4;
+  string phone = 5;
+}

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -3,6 +3,7 @@ package com.linkedout.proto;
 
 import "services/jobs.proto";
 import "services/messaging.proto";
+import "services/employer.proto";
 
 // Message that contains a generic request
 message Request {
@@ -14,5 +15,6 @@ message Request {
     services.GetJobCategoriesRequest get_job_categories_request = 4;
     services.GetUserMessageChannelsRequest get_user_message_channels_request = 5;
     services.GetUserMessageChannelByIdRequest get_user_message_channel_by_id_request = 6;
+    services.GetEmployerRequest get_employer_request = 7;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -3,6 +3,7 @@ package com.linkedout.proto;
 
 import "services/jobs.proto";
 import "services/messaging.proto";
+import "services/employer.proto";
 
 // Message that contains a generic response
 message Error {
@@ -20,5 +21,6 @@ message Response {
     services.GetJobCategoriesResponse get_job_categories_response = 5;
     services.GetUserMessageChannelsResponse get_user_message_channels_response = 6;
     services.GetUserMessageChannelByIdResponse get_user_message_channel_by_id_response = 7;
+    services.GetEmployerResponse get_employer_response = 8;
   }
 }

--- a/backend/protobuf/src/main/proto/services/employer.proto
+++ b/backend/protobuf/src/main/proto/services/employer.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package com.linkedout.proto.services;
+
+import "models/employer.proto";
+
+// Get an employer
+message GetEmployerRequest {
+  string id = 1;
+}
+
+message GetEmployerResponse {
+  models.Employer employer = 1;
+}

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 rootProject.name = "linkedout-backend"
 include("api_gateway")
 include("common")
+include("employer")
 include("jobs")
 include("messaging")
 include("protobuf")

--- a/config/postgres/init.sql
+++ b/config/postgres/init.sql
@@ -13,3 +13,11 @@ CREATE USER messaging
 
 CREATE DATABASE messaging
     OWNER 'messaging';
+
+-- Employer service
+CREATE USER employer
+    WITH LOGIN
+    PASSWORD 'employer';
+
+CREATE DATABASE employer
+    OWNER 'employer';


### PR DESCRIPTION
This adds the skeleton of the `employer` service in the backend. The method to get a single employer through the message broker was also implemented.