### PR TITLE
feat(api_gateway): add employer data in message channels

### DIFF
--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/JobCategoriesController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/JobCategoriesController.kt
@@ -13,6 +13,6 @@ import reactor.core.publisher.Flux
 class JobCategoriesController(private val jobCategoryService: JobCategoryService) {
     @GetMapping
     open fun getJobCategories(request: ServerHttpRequest): Flux<JobCategory> {
-        return jobCategoryService.findAll(request.id)
+        return Flux.fromIterable(jobCategoryService.findAll(request.id))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/JobsController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/JobsController.kt
@@ -15,7 +15,7 @@ import reactor.core.publisher.Mono
 open class JobsController(private val jobService: JobService) {
     @GetMapping
     open fun getJobs(request: ServerHttpRequest): Flux<Job> {
-        return jobService.findAll(request.id)
+        return Flux.fromIterable(jobService.findAll(request.id))
     }
 
     @GetMapping("/{id}")
@@ -23,6 +23,6 @@ open class JobsController(private val jobService: JobService) {
         @PathVariable id: String,
         request: ServerHttpRequest
     ): Mono<Job> {
-        return jobService.findOne(request.id, id)
+        return Mono.just(jobService.findOne(request.id, id))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
@@ -16,7 +16,7 @@ import java.security.Principal
 class MessagingController(private val messageChannelsService: MessageChannelsService) {
     @GetMapping
     open fun getMessageChannelsOfUser(request: ServerHttpRequest, principal: Principal): Flux<MessageChannel> {
-        return messageChannelsService.findAllChannelsOfUser(request.id, principal.name)
+        return Flux.fromIterable(messageChannelsService.findAllChannelsOfUser(request.id, principal.name))
     }
 
     @GetMapping("/{channelId}")
@@ -25,6 +25,6 @@ class MessagingController(private val messageChannelsService: MessageChannelsSer
         principal: Principal,
         @PathVariable channelId: String
     ): Mono<MessageChannel> {
-        return messageChannelsService.findOneChannelOfUser(request.id, principal.name, channelId)
+        return Mono.just(messageChannelsService.findOneChannelOfUser(request.id, principal.name, channelId))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/EmployerService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/EmployerService.kt
@@ -4,13 +4,15 @@ import com.linkedout.backend.model.Employer
 import com.linkedout.common.service.NatsService
 import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.proto.services.Employer.GetEmployerRequest
+import com.linkedout.proto.services.Employer.GetMultipleEmployersRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
 class EmployerService(
     private val natsService: NatsService,
-    @Value("\${app.services.employer.subjects.findOne}") private val findOneSubject: String
+    @Value("\${app.services.employer.subjects.findOne}") private val findOneSubject: String,
+    @Value("\${app.services.employer.subjects.findMultiple}") private val findMultipleSubject: String
 ) {
     fun findOne(requestId: String, id: String): Employer {
         // Request the employer from the employer service
@@ -36,5 +38,33 @@ class EmployerService(
             getEmployerResponse.employer.picture,
             getEmployerResponse.employer.phone
         )
+    }
+
+    fun findMultiple(requestId: String, ids: Iterable<String>): List<Employer> {
+        // Request the employers from the employer service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setGetMultipleEmployersRequest(
+                GetMultipleEmployersRequest.newBuilder()
+                    .addAllIds(ids)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(findMultipleSubject, request)
+
+        // Handle the response
+        if (!response.hasGetMultipleEmployersResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val getMultipleEmployersResponse = response.getMultipleEmployersResponse
+        return getMultipleEmployersResponse.employersList.map { employer ->
+            Employer(
+                employer.id,
+                employer.firstName,
+                employer.lastName,
+                employer.picture,
+                employer.phone
+            )
+        }
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/EmployerService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/EmployerService.kt
@@ -1,0 +1,40 @@
+package com.linkedout.backend.service
+
+import com.linkedout.backend.model.Employer
+import com.linkedout.common.service.NatsService
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.proto.services.Employer.GetEmployerRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class EmployerService(
+    private val natsService: NatsService,
+    @Value("\${app.services.employer.subjects.findOne}") private val findOneSubject: String
+) {
+    fun findOne(requestId: String, id: String): Employer {
+        // Request the employer from the employer service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setGetEmployerRequest(
+                GetEmployerRequest.newBuilder()
+                    .setId(id)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(findOneSubject, request)
+
+        // Handle the response
+        if (!response.hasGetEmployerResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val getEmployerResponse = response.getEmployerResponse
+        return Employer(
+            getEmployerResponse.employer.id,
+            getEmployerResponse.employer.firstName,
+            getEmployerResponse.employer.lastName,
+            getEmployerResponse.employer.picture,
+            getEmployerResponse.employer.phone
+        )
+    }
+}

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobCategoryService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobCategoryService.kt
@@ -5,11 +5,13 @@ import com.linkedout.common.service.NatsService
 import com.linkedout.common.utils.RequestResponseFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import reactor.core.publisher.Flux
 
 @Service
-class JobCategoryService(private val natsService: NatsService, @Value("\${app.services.jobCategories.subjects.findAll}") private val findAllSubject: String) {
-    fun findAll(requestId: String): Flux<JobCategory> {
+class JobCategoryService(
+    private val natsService: NatsService,
+    @Value("\${app.services.jobCategories.subjects.findAll}") private val findAllSubject: String
+) {
+    fun findAll(requestId: String): List<JobCategory> {
         // Request job categories from the jobs service
         val response = natsService.requestWithReply(findAllSubject, RequestResponseFactory.newRequest(requestId).build())
 
@@ -20,9 +22,8 @@ class JobCategoryService(private val natsService: NatsService, @Value("\${app.se
 
         val getJobCategoriesResponse = response.getJobCategoriesResponse
 
-        return Flux.fromIterable(getJobCategoriesResponse.categoriesList)
-            .map { jobCategory ->
-                JobCategory(jobCategory.id, jobCategory.category)
-            }
+        return getJobCategoriesResponse.categoriesList.map { jobCategory ->
+            JobCategory(jobCategory.id, jobCategory.category)
+        }
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/JobService.kt
@@ -6,12 +6,14 @@ import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.proto.services.Jobs.GetJobRequest
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import reactor.core.publisher.Flux
-import reactor.core.publisher.Mono
 
 @Service
-class JobService(private val natsService: NatsService, @Value("\${app.services.jobs.subjects.findAll}") private val findAllSubject: String, @Value("\${app.services.jobs.subjects.findOne}") private val findOneSubject: String) {
-    fun findAll(requestId: String): Flux<Job> {
+class JobService(
+    private val natsService: NatsService,
+    @Value("\${app.services.jobs.subjects.findAll}") private val findAllSubject: String,
+    @Value("\${app.services.jobs.subjects.findOne}") private val findOneSubject: String
+) {
+    fun findAll(requestId: String): List<Job> {
         // Request jobs from the jobs service
         val response = natsService.requestWithReply(findAllSubject, RequestResponseFactory.newRequest(requestId).build())
 
@@ -22,13 +24,12 @@ class JobService(private val natsService: NatsService, @Value("\${app.services.j
 
         val getJobsResponse = response.getJobsResponse
 
-        return Flux.fromIterable(getJobsResponse.jobsList)
-            .map { job ->
-                Job(job.id, job.title, job.category)
-            }
+        return getJobsResponse.jobsList.map { job ->
+            Job(job.id, job.title, job.category)
+        }
     }
 
-    fun findOne(requestId: String, id: String): Mono<Job> {
+    fun findOne(requestId: String, id: String): Job {
         // Request jobs from the jobs service
         val request = RequestResponseFactory.newRequest(requestId)
             .setGetJobRequest(
@@ -45,6 +46,6 @@ class JobService(private val natsService: NatsService, @Value("\${app.services.j
         }
 
         val getJobResponse = response.getJobResponse
-        return Mono.just(Job(getJobResponse.job.id, getJobResponse.job.title, getJobResponse.job.category))
+        return Job(getJobResponse.job.id, getJobResponse.job.title, getJobResponse.job.category)
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
@@ -14,6 +14,7 @@ import reactor.core.publisher.Mono
 @Service
 class MessageChannelsService(
     private val natsService: NatsService,
+    private val employerService: EmployerService,
     @Value("\${app.services.messageChannels.subjects.findAllOfUser}") private val findAllOfUsersSubject: String,
     @Value("\${app.services.messageChannels.subjects.findOneOfUser}") private val findOneOfUserSubject: String
 ) {
@@ -64,11 +65,14 @@ class MessageChannelsService(
         }
 
         val getUserMessageChannelByIdResponse = response.getUserMessageChannelByIdResponse
-        // TODO: Get the employer from the employer service
+
+        // Get the employer from the employer service
+        val employer = employerService.findOne(requestId, getUserMessageChannelByIdResponse.messageChannel.employerId)
+
         return Mono.just(
             MessageChannel(
                 getUserMessageChannelByIdResponse.messageChannel.id,
-                Employer("<TODO>", "<TODO>", "<TODO>", "<TODO>", "<TODO>"),
+                employer,
                 getUserMessageChannelByIdResponse.messageChannel.lastMessage
             )
         )

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelsService.kt
@@ -36,12 +36,15 @@ class MessageChannelsService(
 
         val getUserMessageChannelsResponse = response.getUserMessageChannelsResponse
 
+        // Get the employers from the employer service
+        val employers = employerService.findMultiple(requestId, getUserMessageChannelsResponse.messageChannelsList.map { it.employerId })
+        val employersById = employers.associateBy { it.id }
+
         return Flux.fromIterable(getUserMessageChannelsResponse.messageChannelsList)
             .map { messageChannel ->
-                // TODO: Get the employer from the employer service
                 MessageChannel(
                     messageChannel.id,
-                    Employer("<TODO>", "<TODO>", "<TODO>", "<TODO>", "<TODO>"),
+                    employersById.getOrDefault(messageChannel.employerId, Employer("", "", "", "", "")),
                     messageChannel.lastMessage
                 )
             }

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -29,3 +29,4 @@ app:
     employer:
       subjects:
         findOne: employer.findOne
+        findMultiple: employer.findMultiple

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -26,3 +26,6 @@ app:
       subjects:
         findAllOfUser: messaging.findAllChannelsOfUser
         findOneOfUser: messaging.findOneChannelOfUser
+    employer:
+      subjects:
+        findOne: employer.findOne

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/function/employer/GetMultipleEmployers.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/function/employer/GetMultipleEmployers.kt
@@ -1,0 +1,53 @@
+package com.linkedout.employer.function.employer
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.employer.service.EmployerService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.EmployerOuterClass
+import com.linkedout.proto.services.Employer.GetMultipleEmployersResponse
+import org.springframework.stereotype.Component
+import java.util.UUID
+import java.util.function.Function
+
+@Component
+class GetMultipleEmployers(private val employerService: EmployerService) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Get multiple employers from the database
+        val ids = t.getMultipleEmployersRequest
+            .idsList
+            .map(UUID::fromString)
+
+        val responseMono = employerService.findMultiple(ids)
+            .map { employer ->
+                EmployerOuterClass.Employer.newBuilder()
+                    .setId(employer.id.toString())
+                    .setFirstName(employer.firstName)
+                    .setLastName(employer.lastName)
+                    .setPicture(employer.picture)
+                    .setPhone(employer.phone)
+                    .build()
+            }
+            .reduce(GetMultipleEmployersResponse.newBuilder()) { builder, employer ->
+                builder.addEmployers(employer)
+                builder
+            }
+            .map { builder ->
+                builder.build()
+            }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newSuccessfulResponse()
+                .setGetMultipleEmployersResponse(GetMultipleEmployersResponse.getDefaultInstance())
+                .build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetMultipleEmployersResponse(response)
+            .build()
+    }
+}

--- a/backend/employer/src/main/kotlin/com/linkedout/employer/service/EmployerService.kt
+++ b/backend/employer/src/main/kotlin/com/linkedout/employer/service/EmployerService.kt
@@ -3,6 +3,7 @@ package com.linkedout.employer.service
 import com.linkedout.employer.model.Employer
 import com.linkedout.employer.repository.EmployerRepository
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.UUID
 
@@ -10,5 +11,9 @@ import java.util.UUID
 class EmployerService(private val employerRepository: EmployerRepository) {
     fun findOne(id: UUID): Mono<Employer> {
         return employerRepository.findById(id)
+    }
+
+    fun findMultiple(ids: Iterable<UUID>): Flux<Employer> {
+        return employerRepository.findAllById(ids)
     }
 }

--- a/backend/employer/src/main/resources/application.properties
+++ b/backend/employer/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=getEmployer
+spring.cloud.function.definition=getEmployer;getMultipleEmployers
 
 spring.cloud.stream.bindings.getEmployer-in-0.destination=employer.findOne
 spring.cloud.stream.bindings.getEmployer-in-0.group=employerSvc
@@ -8,5 +8,14 @@ spring.cloud.stream.bindings.getEmployer-out-0.destination=
 spring.cloud.stream.bindings.getEmployer-out-0.group=employerSvc
 spring.cloud.stream.bindings.getEmployer-out-0.binder=nats
 spring.cloud.stream.bindings.getEmployer-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.getMultipleEmployers-in-0.destination=employer.findMultiple
+spring.cloud.stream.bindings.getMultipleEmployers-in-0.group=employerSvc
+spring.cloud.stream.bindings.getMultipleEmployers-in-0.binder=nats
+spring.cloud.stream.bindings.getMultipleEmployers-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getMultipleEmployers-out-0.destination=
+spring.cloud.stream.bindings.getMultipleEmployers-out-0.group=employerSvc
+spring.cloud.stream.bindings.getMultipleEmployers-out-0.binder=nats
+spring.cloud.stream.bindings.getMultipleEmployers-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -16,5 +16,6 @@ message Request {
     services.GetUserMessageChannelsRequest get_user_message_channels_request = 5;
     services.GetUserMessageChannelByIdRequest get_user_message_channel_by_id_request = 6;
     services.GetEmployerRequest get_employer_request = 7;
+    services.GetMultipleEmployersRequest get_multiple_employers_request = 8;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -22,5 +22,6 @@ message Response {
     services.GetUserMessageChannelsResponse get_user_message_channels_response = 6;
     services.GetUserMessageChannelByIdResponse get_user_message_channel_by_id_response = 7;
     services.GetEmployerResponse get_employer_response = 8;
+    services.GetMultipleEmployersResponse get_multiple_employers_response = 9;
   }
 }

--- a/backend/protobuf/src/main/proto/services/employer.proto
+++ b/backend/protobuf/src/main/proto/services/employer.proto
@@ -11,3 +11,12 @@ message GetEmployerRequest {
 message GetEmployerResponse {
   models.Employer employer = 1;
 }
+
+// Get multiple employers
+message GetMultipleEmployersRequest {
+  repeated string ids = 1;
+}
+
+message GetMultipleEmployersResponse {
+  repeated models.Employer employers = 1;
+}


### PR DESCRIPTION
This adds data about the employer on the `/messaging` and `/messaging/{channelId}` route responses by using the new `employer` service.

## Other changes

In the API gateway, reactive types were moved out of the services and now handled exclusively in the controllers.