### PR TITLE
feat(messaging): implement getMessagesOfUser

### DIFF
--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
@@ -1,7 +1,9 @@
 package com.linkedout.backend.controller
 
+import com.linkedout.backend.model.Message
 import com.linkedout.backend.model.MessageChannel
 import com.linkedout.backend.service.MessageChannelsService
+import com.linkedout.backend.service.MessageService
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -13,7 +15,10 @@ import java.security.Principal
 
 @RestController
 @RequestMapping("/api/v1/messaging")
-class MessagingController(private val messageChannelsService: MessageChannelsService) {
+class MessagingController(
+    private val messageChannelsService: MessageChannelsService,
+    private val messageService: MessageService
+) {
     @GetMapping
     open fun getMessageChannelsOfUser(request: ServerHttpRequest, principal: Principal): Flux<MessageChannel> {
         return Flux.fromIterable(messageChannelsService.findAllChannelsOfUser(request.id, principal.name))
@@ -26,5 +31,14 @@ class MessagingController(private val messageChannelsService: MessageChannelsSer
         @PathVariable channelId: String
     ): Mono<MessageChannel> {
         return Mono.just(messageChannelsService.findOneChannelOfUser(request.id, principal.name, channelId))
+    }
+
+    @GetMapping("/{channelId}/messages")
+    open fun getMessagesOfUserInChannel(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @PathVariable channelId: String
+    ): Flux<Message> {
+        return Flux.fromIterable(messageService.findAllMessagesOfUserInChannel(request.id, principal.name, channelId))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
@@ -2,7 +2,7 @@ package com.linkedout.backend.controller
 
 import com.linkedout.backend.model.Message
 import com.linkedout.backend.model.MessageChannel
-import com.linkedout.backend.service.MessageChannelsService
+import com.linkedout.backend.service.MessageChannelService
 import com.linkedout.backend.service.MessageService
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.GetMapping
@@ -16,12 +16,12 @@ import java.security.Principal
 @RestController
 @RequestMapping("/api/v1/messaging")
 class MessagingController(
-    private val messageChannelsService: MessageChannelsService,
+    private val messageChannelService: MessageChannelService,
     private val messageService: MessageService
 ) {
     @GetMapping
     open fun getMessageChannelsOfUser(request: ServerHttpRequest, principal: Principal): Flux<MessageChannel> {
-        return Flux.fromIterable(messageChannelsService.findAllChannelsOfUser(request.id, principal.name))
+        return Flux.fromIterable(messageChannelService.findAllChannelsOfUser(request.id, principal.name))
     }
 
     @GetMapping("/{channelId}")
@@ -30,7 +30,7 @@ class MessagingController(
         principal: Principal,
         @PathVariable channelId: String
     ): Mono<MessageChannel> {
-        return Mono.just(messageChannelsService.findOneChannelOfUser(request.id, principal.name, channelId))
+        return Mono.just(messageChannelService.findOneChannelOfUser(request.id, principal.name, channelId))
     }
 
     @GetMapping("/{channelId}/messages")

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/model/Message.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/model/Message.kt
@@ -1,0 +1,10 @@
+package com.linkedout.backend.model
+
+data class Message(
+    val id: String,
+    val channelId: String,
+    val employerId: String,
+    val direction: Int,
+    val sentAt: String,
+    val content: String
+)

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelService.kt
@@ -50,8 +50,8 @@ class MessageChannelService(
     fun findOneChannelOfUser(requestId: String, userId: String, channelId: String): MessageChannel {
         // Request message channel from the messaging service
         val request = RequestResponseFactory.newRequest(requestId)
-            .setGetUserMessageChannelByIdRequest(
-                Messaging.GetUserMessageChannelByIdRequest.newBuilder()
+            .setGetUserMessageChannelRequest(
+                Messaging.GetUserMessageChannelRequest.newBuilder()
                     .setUserId(userId)
                     .setMessageChannelId(channelId)
             )
@@ -60,11 +60,11 @@ class MessageChannelService(
         val response = natsService.requestWithReply(findOneOfUserSubject, request)
 
         // Handle the response
-        if (!response.hasGetUserMessageChannelByIdResponse()) {
+        if (!response.hasGetUserMessageChannelResponse()) {
             throw Exception("Invalid response")
         }
 
-        val getUserMessageChannelByIdResponse = response.getUserMessageChannelByIdResponse
+        val getUserMessageChannelByIdResponse = response.getUserMessageChannelResponse
 
         // Get the employer from the employer service
         val employer = employerService.findOne(requestId, getUserMessageChannelByIdResponse.messageChannel.employerId)

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageChannelService.kt
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
 @Service
-class MessageChannelsService(
+class MessageChannelService(
     private val natsService: NatsService,
     private val employerService: EmployerService,
     @Value("\${app.services.messageChannels.subjects.findAllOfUser}") private val findAllOfUsersSubject: String,

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageService.kt
@@ -1,0 +1,49 @@
+package com.linkedout.backend.service
+
+import com.linkedout.backend.model.Message
+import com.linkedout.common.service.NatsService
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.proto.services.Messaging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+@Service
+class MessageService(
+    private val natsService: NatsService,
+    @Value("\${app.services.messages.subjects.findAllOfUserInChannel}") private val findAllOfUserInChannelSubject: String
+) {
+    fun findAllMessagesOfUserInChannel(requestId: String, userId: String, channelId: String): List<Message> {
+        // Request messages from the messaging service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setGetUserMessagesRequest(
+                Messaging.GetUserMessagesRequest.newBuilder()
+                    .setUserId(userId)
+                    .setMessageChannelId(channelId)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(findAllOfUserInChannelSubject, request)
+
+        // Handle the response
+        if (!response.hasGetUserMessagesResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val getUserMessagesResponse = response.getUserMessagesResponse
+
+        return getUserMessagesResponse.messagesList.map { message ->
+            val date = Date(message.sentAt)
+
+            Message(
+                message.id,
+                getUserMessagesResponse.messageChannelId,
+                getUserMessagesResponse.employerId,
+                message.directionValue,
+                DateTimeFormatter.ISO_INSTANT.format(date.toInstant()),
+                message.content
+            )
+        }
+    }
+}

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -26,6 +26,9 @@ app:
       subjects:
         findAllOfUser: messaging.findAllChannelsOfUser
         findOneOfUser: messaging.findOneChannelOfUser
+    messages:
+      subjects:
+        findAllOfUserInChannel: messaging.findAllMessagesOfUserInChannel
     employer:
       subjects:
         findOne: employer.findOne

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUser.kt
@@ -5,7 +5,7 @@ import com.linkedout.messaging.service.MessageChannelService
 import com.linkedout.proto.RequestOuterClass.Request
 import com.linkedout.proto.ResponseOuterClass.Response
 import com.linkedout.proto.models.MessageChannelOuterClass
-import com.linkedout.proto.services.Messaging.GetUserMessageChannelByIdResponse
+import com.linkedout.proto.services.Messaging.GetUserMessageChannelResponse
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import java.util.*
@@ -15,7 +15,7 @@ import java.util.function.Function
 class GetChannelOfUser(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
     override fun apply(t: Request): Response {
         // Get the message channel from the database
-        val request = t.getUserMessageChannelByIdRequest
+        val request = t.getUserMessageChannelRequest
         val responseMono = messageChannelService.findOneWithSeasonworkerId(UUID.fromString(request.userId), UUID.fromString(request.messageChannelId))
             .map { messageChannel ->
                 // TODO: Get the last message
@@ -26,7 +26,7 @@ class GetChannelOfUser(private val messageChannelService: MessageChannelService)
                     .build()
             }
             .map { messageChannel ->
-                GetUserMessageChannelByIdResponse.newBuilder()
+                GetUserMessageChannelResponse.newBuilder()
                     .setMessageChannel(messageChannel)
                     .build()
             }
@@ -40,7 +40,7 @@ class GetChannelOfUser(private val messageChannelService: MessageChannelService)
             ?: return RequestResponseFactory.newFailedResponse("Message channel not found", HttpStatus.NOT_FOUND).build()
 
         return RequestResponseFactory.newSuccessfulResponse()
-            .setGetUserMessageChannelByIdResponse(response)
+            .setGetUserMessageChannelResponse(response)
             .build()
     }
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/GetMessagesOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/GetMessagesOfUser.kt
@@ -1,0 +1,69 @@
+package com.linkedout.messaging.function.messages
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.messaging.service.MessageChannelService
+import com.linkedout.messaging.service.MessageService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.MessageOuterClass.Message
+import com.linkedout.proto.services.Messaging.GetUserMessagesResponse
+import org.springframework.stereotype.Component
+import java.time.ZoneOffset
+import java.util.*
+import java.util.function.Function
+
+@Component
+class GetMessagesOfUser(
+    private val messageService: MessageService,
+    private val messageChannelService: MessageChannelService
+) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Extract the request
+        val request = t.getUserMessagesRequest
+        val userId = UUID.fromString(request.userId)
+        val messageChannelId = UUID.fromString(request.messageChannelId)
+
+        // Get the message channel from the database
+        val messageChannel = try {
+            messageChannelService.findOneWithSeasonworkerId(userId, messageChannelId)
+                .block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Message channel not found").build()
+
+        // Get the messages from the database
+        val responseMono = messageService.findAllWithSeasonworkerIdAndMessageChannelId(userId, messageChannelId)
+            .map { message ->
+                Message.newBuilder()
+                    .setId(message.id.toString())
+                    .setDirectionValue(message.direction)
+                    .setSentAt(message.created.toEpochSecond(ZoneOffset.UTC) * 1000)
+                    .setContent(message.message)
+                    .build()
+            }
+            .reduce(GetUserMessagesResponse.newBuilder()) { builder, message ->
+                builder.addMessages(message)
+                builder
+            }
+            .map { builder ->
+                builder.setMessageChannelId(request.messageChannelId)
+                builder.setEmployerId(messageChannel.employerId.toString())
+                builder.build()
+            }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newSuccessfulResponse()
+                .setGetUserMessagesResponse(GetUserMessagesResponse.getDefaultInstance())
+                .build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetUserMessagesResponse(response)
+            .build()
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/Message.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/Message.kt
@@ -1,0 +1,18 @@
+package com.linkedout.messaging.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Table("message")
+data class Message(
+    @Id
+    val id: UUID,
+    @Column("messagechannelid")
+    val messageChannelId: UUID,
+    val direction: Int,
+    val message: String,
+    val created: LocalDateTime
+)

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageRepository.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageRepository.kt
@@ -1,0 +1,19 @@
+package com.linkedout.messaging.repository
+
+import com.linkedout.messaging.model.Message
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+import java.util.UUID
+
+interface MessageRepository : ReactiveCrudRepository<Message, UUID> {
+    @Query(
+        """
+        SELECT m.* FROM message m
+        JOIN messagechannel mc on mc.id = m.messagechannelid
+        WHERE m.messagechannelid = :messageChannelId
+        AND mc.seasonworkerid = :seasonworkerId
+    """
+    )
+    fun findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId: UUID, messageChannelId: UUID): Flux<Message>
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageService.kt
@@ -1,0 +1,14 @@
+package com.linkedout.messaging.service
+
+import com.linkedout.messaging.model.Message
+import com.linkedout.messaging.repository.MessageRepository
+import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import java.util.UUID
+
+@Service
+class MessageService(private val messageRepository: MessageRepository) {
+    fun findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId: UUID, messageChannelId: UUID): Flux<Message> {
+        return messageRepository.findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId, messageChannelId)
+    }
+}

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser
+spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser
 
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.destination=messaging.findAllChannelsOfUser
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.group=messagingSvc
@@ -17,5 +17,14 @@ spring.cloud.stream.bindings.getChannelOfUser-out-0.destination=
 spring.cloud.stream.bindings.getChannelOfUser-out-0.group=messagingSvc
 spring.cloud.stream.bindings.getChannelOfUser-out-0.binder=nats
 spring.cloud.stream.bindings.getChannelOfUser-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.getMessagesOfUser-in-0.destination=messaging.findAllMessagesOfUserInChannel
+spring.cloud.stream.bindings.getMessagesOfUser-in-0.group=messagingSvc
+spring.cloud.stream.bindings.getMessagesOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.getMessagesOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getMessagesOfUser-out-0.destination=
+spring.cloud.stream.bindings.getMessagesOfUser-out-0.group=messagingSvc
+spring.cloud.stream.bindings.getMessagesOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.getMessagesOfUser-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
+++ b/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
@@ -1,5 +1,5 @@
 CREATE TABLE MessageChannel (
-                             id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                             seasonworkerId UUID NOT NULL,
-                             employerId UUID NOT NULL
+                                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                seasonworkerId UUID NOT NULL,
+                                employerId UUID NOT NULL
 );

--- a/backend/messaging/src/main/resources/db/migration/V2__add_message_table.sql
+++ b/backend/messaging/src/main/resources/db/migration/V2__add_message_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE Message (
+                         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                         messageChannelId UUID NOT NULL,
+                         direction INT NOT NULL,
+                         message VARCHAR(4096) NOT NULL,
+                         created TIMESTAMP NOT NULL DEFAULT NOW(),
+                         FOREIGN KEY (messageChannelId) REFERENCES MessageChannel(id),
+                         CHECK (direction IN (0, 1))
+);

--- a/backend/protobuf/src/main/proto/models/employer.proto
+++ b/backend/protobuf/src/main/proto/models/employer.proto
@@ -3,8 +3,8 @@ package com.linkedout.proto.models;
 
 message Employer {
   string id = 1;
-  string firstName = 2;
-  string lastName = 3;
+  string first_name = 2;
+  string last_name = 3;
   string picture = 4;
   string phone = 5;
 }

--- a/backend/protobuf/src/main/proto/models/message.proto
+++ b/backend/protobuf/src/main/proto/models/message.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package com.linkedout.proto.models;
+
+message Message {
+  enum Direction {
+    ToEmployer = 0;
+    ToSeasonworker = 1;
+  }
+
+  string id = 1;
+  Direction direction = 2;
+  uint64 sent_at = 3;
+  string content = 4;
+}

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -17,5 +17,6 @@ message Request {
     services.GetUserMessageChannelByIdRequest get_user_message_channel_by_id_request = 6;
     services.GetEmployerRequest get_employer_request = 7;
     services.GetMultipleEmployersRequest get_multiple_employers_request = 8;
+    services.GetUserMessagesRequest get_user_messages_request = 9;
   }
 }

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -14,7 +14,7 @@ message Request {
     services.GetJobRequest get_job_request = 3;
     services.GetJobCategoriesRequest get_job_categories_request = 4;
     services.GetUserMessageChannelsRequest get_user_message_channels_request = 5;
-    services.GetUserMessageChannelByIdRequest get_user_message_channel_by_id_request = 6;
+    services.GetUserMessageChannelRequest get_user_message_channel_request = 6;
     services.GetEmployerRequest get_employer_request = 7;
     services.GetMultipleEmployersRequest get_multiple_employers_request = 8;
     services.GetUserMessagesRequest get_user_messages_request = 9;

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -23,5 +23,6 @@ message Response {
     services.GetUserMessageChannelByIdResponse get_user_message_channel_by_id_response = 7;
     services.GetEmployerResponse get_employer_response = 8;
     services.GetMultipleEmployersResponse get_multiple_employers_response = 9;
+    services.GetUserMessagesResponse get_user_messages_response = 10;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -20,7 +20,7 @@ message Response {
     services.GetJobResponse get_job_response = 4;
     services.GetJobCategoriesResponse get_job_categories_response = 5;
     services.GetUserMessageChannelsResponse get_user_message_channels_response = 6;
-    services.GetUserMessageChannelByIdResponse get_user_message_channel_by_id_response = 7;
+    services.GetUserMessageChannelResponse get_user_message_channel_response = 7;
     services.GetEmployerResponse get_employer_response = 8;
     services.GetMultipleEmployersResponse get_multiple_employers_response = 9;
     services.GetUserMessagesResponse get_user_messages_response = 10;

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -13,13 +13,13 @@ message GetUserMessageChannelsResponse {
     repeated models.MessageChannel message_channels = 1;
 }
 
-// Get a message channel of a user by id
-message GetUserMessageChannelByIdRequest {
+// Get a message channel of a user
+message GetUserMessageChannelRequest {
     string user_id = 1;
     string message_channel_id = 2;
 }
 
-message GetUserMessageChannelByIdResponse {
+message GetUserMessageChannelResponse {
     models.MessageChannel message_channel = 1;
 }
 

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package com.linkedout.proto.services;
 
+import "models/message.proto";
 import "models/messageChannel.proto";
 
 // Get message channels of a user
@@ -20,4 +21,16 @@ message GetUserMessageChannelByIdRequest {
 
 message GetUserMessageChannelByIdResponse {
     models.MessageChannel messageChannel = 1;
+}
+
+// Get messages of a message channel and user
+message GetUserMessagesRequest {
+    string userId = 1;
+    string messageChannelId = 2;
+}
+
+message GetUserMessagesResponse {
+    string messageChannelId = 1;
+    string employerId = 2;
+    repeated models.Message messages = 3;
 }

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -6,31 +6,31 @@ import "models/messageChannel.proto";
 
 // Get message channels of a user
 message GetUserMessageChannelsRequest {
-    string userId = 1;
+    string user_id = 1;
 }
 
 message GetUserMessageChannelsResponse {
-    repeated models.MessageChannel messageChannels = 1;
+    repeated models.MessageChannel message_channels = 1;
 }
 
 // Get a message channel of a user by id
 message GetUserMessageChannelByIdRequest {
-    string userId = 1;
-    string messageChannelId = 2;
+    string user_id = 1;
+    string message_channel_id = 2;
 }
 
 message GetUserMessageChannelByIdResponse {
-    models.MessageChannel messageChannel = 1;
+    models.MessageChannel message_channel = 1;
 }
 
 // Get messages of a message channel and user
 message GetUserMessagesRequest {
-    string userId = 1;
-    string messageChannelId = 2;
+    string user_id = 1;
+    string message_channel_id = 2;
 }
 
 message GetUserMessagesResponse {
-    string messageChannelId = 1;
-    string employerId = 2;
+    string message_channel_id = 1;
+    string employer_id = 2;
     repeated models.Message messages = 3;
 }


### PR DESCRIPTION
This implements the method in the messaging service to get the messages in a message channel of a user through the message broker.

The corresponding API gateway route was also implemented for the currently logged-in user.

## Other changes

In the API gateway, the `MessageChannelsService` class was renamed to `MessageChannelService`.

In the protobuf files, snake case is enforced on message properties. The `get_user_message_channel_by_id_*` items were renamed to `get_user_message_channel_*`.