### PR TITLE
feat(messaging): finish implementation

### DIFF
--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/EmployerController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/EmployerController.kt
@@ -1,21 +1,34 @@
 package com.linkedout.backend.controller
 
 import com.linkedout.backend.model.Employer
+import com.linkedout.backend.model.MessageChannel
 import com.linkedout.backend.service.EmployerService
+import com.linkedout.backend.service.MessageChannelService
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
+import java.security.Principal
 
 @RestController
 @RequestMapping("/api/v1/employers")
 class EmployerController(
-    private val employerService: EmployerService
+    private val employerService: EmployerService,
+    private val messageChannelService: MessageChannelService
 ) {
     @GetMapping("/{employerId}")
     open fun getEmployerById(request: ServerHttpRequest, @PathVariable employerId: String): Mono<Employer> {
         return Mono.just(employerService.findOne(request.id, employerId))
+    }
+
+    @GetMapping("/{employerId}/messaging")
+    open fun getEmployerMessaging(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @PathVariable employerId: String
+    ): Mono<MessageChannel> {
+        return Mono.just(messageChannelService.findOneChannelOfUserWithEmployer(request.id, principal.name, employerId))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/EmployerController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/EmployerController.kt
@@ -1,12 +1,17 @@
 package com.linkedout.backend.controller
 
+import com.linkedout.backend.dto.messaging.SendMessageDto
 import com.linkedout.backend.model.Employer
+import com.linkedout.backend.model.Message
 import com.linkedout.backend.model.MessageChannel
 import com.linkedout.backend.service.EmployerService
 import com.linkedout.backend.service.MessageChannelService
+import com.linkedout.backend.service.MessageService
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
@@ -16,7 +21,8 @@ import java.security.Principal
 @RequestMapping("/api/v1/employers")
 class EmployerController(
     private val employerService: EmployerService,
-    private val messageChannelService: MessageChannelService
+    private val messageChannelService: MessageChannelService,
+    private val messageService: MessageService
 ) {
     @GetMapping("/{employerId}")
     open fun getEmployerById(request: ServerHttpRequest, @PathVariable employerId: String): Mono<Employer> {
@@ -30,5 +36,15 @@ class EmployerController(
         @PathVariable employerId: String
     ): Mono<MessageChannel> {
         return Mono.just(messageChannelService.findOneChannelOfUserWithEmployer(request.id, principal.name, employerId))
+    }
+
+    @PostMapping("/{employerId}/messaging")
+    open fun sendMessage(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @PathVariable employerId: String,
+        @RequestBody body: SendMessageDto
+    ): Mono<Message> {
+        return Mono.just(messageService.sendMessageToEmployer(request.id, principal.name, employerId, body.content))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/MessagingController.kt
@@ -1,5 +1,6 @@
 package com.linkedout.backend.controller
 
+import com.linkedout.backend.dto.messaging.SendMessageDto
 import com.linkedout.backend.model.Message
 import com.linkedout.backend.model.MessageChannel
 import com.linkedout.backend.service.MessageChannelService
@@ -7,6 +8,8 @@ import com.linkedout.backend.service.MessageService
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Flux
@@ -40,5 +43,15 @@ class MessagingController(
         @PathVariable channelId: String
     ): Flux<Message> {
         return Flux.fromIterable(messageService.findAllMessagesOfUserInChannel(request.id, principal.name, channelId))
+    }
+
+    @PostMapping("/{channelId}/messages")
+    open fun sendMessage(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @PathVariable channelId: String,
+        @RequestBody body: SendMessageDto
+    ): Mono<Message> {
+        return Mono.just(messageService.sendMessage(request.id, principal.name, channelId, body.content))
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/dto/messaging/SendMessageDto.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/dto/messaging/SendMessageDto.kt
@@ -1,0 +1,5 @@
+package com.linkedout.backend.dto.messaging
+
+data class SendMessageDto(
+    val content: String
+)

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageService.kt
@@ -3,6 +3,7 @@ package com.linkedout.backend.service
 import com.linkedout.backend.model.Message
 import com.linkedout.common.service.NatsService
 import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.proto.models.MessageOuterClass
 import com.linkedout.proto.services.Messaging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -12,7 +13,8 @@ import java.util.*
 @Service
 class MessageService(
     private val natsService: NatsService,
-    @Value("\${app.services.messages.subjects.findAllOfUserInChannel}") private val findAllOfUserInChannelSubject: String
+    @Value("\${app.services.messages.subjects.findAllOfUserInChannel}") private val findAllOfUserInChannelSubject: String,
+    @Value("\${app.services.messages.subjects.sendMessage}") private val sendMessageSubject: String
 ) {
     fun findAllMessagesOfUserInChannel(requestId: String, userId: String, channelId: String): List<Message> {
         // Request messages from the messaging service
@@ -45,5 +47,37 @@ class MessageService(
                 message.content
             )
         }
+    }
+
+    fun sendMessage(requestId: String, userId: String, channelId: String, content: String): Message {
+        // Send the message using the messaging service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setSendMessageRequest(
+                Messaging.SendMessageRequest.newBuilder()
+                    .setUserId(userId)
+                    .setMessageChannelId(channelId)
+                    .setContent(content)
+                    .setDirection(MessageOuterClass.Message.Direction.ToEmployer)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(sendMessageSubject, request)
+
+        // Handle the response
+        if (!response.hasSendMessageResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val sendMessageResponse = response.sendMessageResponse
+        val sentAt = Date(sendMessageResponse.message.sentAt)
+
+        return Message(
+            sendMessageResponse.message.id,
+            sendMessageResponse.messageChannelId,
+            sendMessageResponse.employerId,
+            sendMessageResponse.message.directionValue,
+            DateTimeFormatter.ISO_INSTANT.format(sentAt.toInstant()),
+            sendMessageResponse.message.content
+        )
     }
 }

--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageService.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/service/MessageService.kt
@@ -14,7 +14,8 @@ import java.util.*
 class MessageService(
     private val natsService: NatsService,
     @Value("\${app.services.messages.subjects.findAllOfUserInChannel}") private val findAllOfUserInChannelSubject: String,
-    @Value("\${app.services.messages.subjects.sendMessage}") private val sendMessageSubject: String
+    @Value("\${app.services.messages.subjects.sendMessage}") private val sendMessageSubject: String,
+    @Value("\${app.services.messages.subjects.sendMessageToEmployer}") private val sendMessageToEmployerSubject: String
 ) {
     fun findAllMessagesOfUserInChannel(requestId: String, userId: String, channelId: String): List<Message> {
         // Request messages from the messaging service
@@ -78,6 +79,37 @@ class MessageService(
             sendMessageResponse.message.directionValue,
             DateTimeFormatter.ISO_INSTANT.format(sentAt.toInstant()),
             sendMessageResponse.message.content
+        )
+    }
+
+    fun sendMessageToEmployer(requestId: String, userId: String, employerId: String, content: String): Message {
+        // Send the message using the messaging service
+        val request = RequestResponseFactory.newRequest(requestId)
+            .setSendMessageToEmployerRequest(
+                Messaging.SendMessageToEmployerRequest.newBuilder()
+                    .setUserId(userId)
+                    .setEmployerId(employerId)
+                    .setContent(content)
+            )
+            .build()
+
+        val response = natsService.requestWithReply(sendMessageToEmployerSubject, request)
+
+        // Handle the response
+        if (!response.hasSendMessageToEmployerResponse()) {
+            throw Exception("Invalid response")
+        }
+
+        val sendMessageToEmployerResponse = response.sendMessageToEmployerResponse
+        val sentAt = Date(sendMessageToEmployerResponse.message.sentAt)
+
+        return Message(
+            sendMessageToEmployerResponse.message.id,
+            sendMessageToEmployerResponse.messageChannelId,
+            sendMessageToEmployerResponse.employerId,
+            sendMessageToEmployerResponse.message.directionValue,
+            DateTimeFormatter.ISO_INSTANT.format(sentAt.toInstant()),
+            sendMessageToEmployerResponse.message.content
         )
     }
 }

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -26,6 +26,7 @@ app:
       subjects:
         findAllOfUser: messaging.findAllChannelsOfUser
         findOneOfUser: messaging.findOneChannelOfUser
+        findOneOfUserWithEmployer: messaging.findOneChannelOfUserWithEmployer
     messages:
       subjects:
         findAllOfUserInChannel: messaging.findAllMessagesOfUserInChannel

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -31,6 +31,7 @@ app:
       subjects:
         findAllOfUserInChannel: messaging.findAllMessagesOfUserInChannel
         sendMessage: messaging.sendMessage
+        sendMessageToEmployer: messaging.sendMessageToEmployer
     employer:
       subjects:
         findOne: employer.findOne

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -29,6 +29,7 @@ app:
     messages:
       subjects:
         findAllOfUserInChannel: messaging.findAllMessagesOfUserInChannel
+        sendMessage: messaging.sendMessage
     employer:
       subjects:
         findOne: employer.findOne

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUser.kt
@@ -18,11 +18,10 @@ class GetChannelOfUser(private val messageChannelService: MessageChannelService)
         val request = t.getUserMessageChannelRequest
         val responseMono = messageChannelService.findOneWithSeasonworkerId(UUID.fromString(request.userId), UUID.fromString(request.messageChannelId))
             .map { messageChannel ->
-                // TODO: Get the last message
                 MessageChannelOuterClass.MessageChannel.newBuilder()
                     .setId(messageChannel.id.toString())
                     .setEmployerId(messageChannel.employerId.toString())
-                    .setLastMessage("<TODO>")
+                    .setLastMessage(messageChannel.lastMessage ?: "")
                     .build()
             }
             .map { messageChannel ->

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUserWithEmployer.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUserWithEmployer.kt
@@ -1,0 +1,46 @@
+package com.linkedout.messaging.function.messageChannels
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.messaging.service.MessageChannelService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.MessageChannelOuterClass
+import com.linkedout.proto.services.Messaging
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.function.Function
+
+@Component
+class GetChannelOfUserWithEmployer(private val messageChannelService: MessageChannelService) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Get the message channel from the database
+        val request = t.getUserMessageChannelWithEmployerRequest
+        val responseMono = messageChannelService.findOneWithSeasonworkerIdAndEmployerId(UUID.fromString(request.userId), UUID.fromString(request.employerId))
+            .map { messageChannel ->
+                // TODO: Get the last message
+                MessageChannelOuterClass.MessageChannel.newBuilder()
+                    .setId(messageChannel.id.toString())
+                    .setEmployerId(messageChannel.employerId.toString())
+                    .setLastMessage("<TODO>")
+                    .build()
+            }
+            .map { messageChannel ->
+                Messaging.GetUserMessageChannelWithEmployerResponse.newBuilder()
+                    .setMessageChannel(messageChannel)
+                    .build()
+            }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Message channel not found", HttpStatus.NOT_FOUND).build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetUserMessageChannelWithEmployerResponse(response)
+            .build()
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUserWithEmployer.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelOfUserWithEmployer.kt
@@ -18,11 +18,10 @@ class GetChannelOfUserWithEmployer(private val messageChannelService: MessageCha
         val request = t.getUserMessageChannelWithEmployerRequest
         val responseMono = messageChannelService.findOneWithSeasonworkerIdAndEmployerId(UUID.fromString(request.userId), UUID.fromString(request.employerId))
             .map { messageChannel ->
-                // TODO: Get the last message
                 MessageChannelOuterClass.MessageChannel.newBuilder()
                     .setId(messageChannel.id.toString())
                     .setEmployerId(messageChannel.employerId.toString())
-                    .setLastMessage("<TODO>")
+                    .setLastMessage(messageChannel.lastMessage ?: "")
                     .build()
             }
             .map { messageChannel ->

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelsOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messageChannels/GetChannelsOfUser.kt
@@ -16,11 +16,10 @@ class GetChannelsOfUser(private val messageChannelService: MessageChannelService
         // Get the message channels from the database
         val responseMono = messageChannelService.findAllWithSeasonworkerId(UUID.fromString(t.getUserMessageChannelsRequest.userId))
             .map { messageChannel ->
-                // TODO: Get the last message
                 MessageChannel.newBuilder()
                     .setId(messageChannel.id.toString())
                     .setEmployerId(messageChannel.employerId.toString())
-                    .setLastMessage("<TODO>")
+                    .setLastMessage(messageChannel.lastMessage ?: "")
                     .build()
             }
             .reduce(GetUserMessageChannelsResponse.newBuilder()) { builder, messageChannel ->

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/GetMessagesOfUser.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/GetMessagesOfUser.kt
@@ -3,6 +3,7 @@ package com.linkedout.messaging.function.messages
 import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.messaging.service.MessageChannelService
 import com.linkedout.messaging.service.MessageService
+import com.linkedout.messaging.utils.MessageDirection
 import com.linkedout.proto.RequestOuterClass.Request
 import com.linkedout.proto.ResponseOuterClass.Response
 import com.linkedout.proto.models.MessageOuterClass.Message
@@ -37,7 +38,7 @@ class GetMessagesOfUser(
             .map { message ->
                 Message.newBuilder()
                     .setId(message.id.toString())
-                    .setDirectionValue(message.direction)
+                    .setDirection(MessageDirection.toProto(message.direction))
                     .setSentAt(message.created.toEpochSecond(ZoneOffset.UTC) * 1000)
                     .setContent(message.message)
                     .build()

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessage.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessage.kt
@@ -1,0 +1,70 @@
+package com.linkedout.messaging.function.messages
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.messaging.service.MessageChannelService
+import com.linkedout.messaging.service.MessageService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.MessageOuterClass
+import com.linkedout.proto.services.Messaging.SendMessageResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import java.time.ZoneOffset
+import java.util.*
+import java.util.function.Function
+
+@Component
+class SendMessage(
+    private val messageService: MessageService,
+    private val messageChannelService: MessageChannelService
+) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Extract the request
+        val request = t.sendMessageRequest
+        val userId = UUID.fromString(request.userId)
+        val messageChannelId = UUID.fromString(request.messageChannelId)
+
+        // Get the message channel from the database
+        val messageChannel = try {
+            messageChannelService.findOneWithSeasonworkerId(userId, messageChannelId)
+                .block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Message channel not found").build()
+
+        // Insert the message into the database
+        val responseMono = try {
+            messageService.saveMessage(userId, messageChannelId, request.content, request.directionValue)
+                .map { message ->
+                    MessageOuterClass.Message.newBuilder()
+                        .setId(message.id.toString())
+                        .setDirectionValue(message.direction)
+                        .setSentAt(message.created.toEpochSecond(ZoneOffset.UTC) * 1000)
+                        .setContent(message.message)
+                        .build()
+                }
+                .map { builder ->
+                    SendMessageResponse.newBuilder()
+                        .setMessageChannelId(messageChannelId.toString())
+                        .setEmployerId(messageChannel.employerId.toString())
+                        .setMessage(builder)
+                        .build()
+                }
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Unable to send the message", HttpStatus.INTERNAL_SERVER_ERROR).build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setSendMessageResponse(response)
+            .build()
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessage.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessage.kt
@@ -3,6 +3,7 @@ package com.linkedout.messaging.function.messages
 import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.messaging.service.MessageChannelService
 import com.linkedout.messaging.service.MessageService
+import com.linkedout.messaging.utils.MessageDirection
 import com.linkedout.proto.RequestOuterClass.Request
 import com.linkedout.proto.ResponseOuterClass.Response
 import com.linkedout.proto.models.MessageOuterClass
@@ -35,11 +36,11 @@ class SendMessage(
 
         // Insert the message into the database
         val responseMono = try {
-            messageService.saveMessage(userId, messageChannelId, request.content, request.directionValue)
+            messageService.saveMessage(userId, messageChannelId, request.content, MessageDirection.fromProto(request.direction))
                 .map { message ->
                     MessageOuterClass.Message.newBuilder()
                         .setId(message.id.toString())
-                        .setDirectionValue(message.direction)
+                        .setDirection(MessageDirection.toProto(message.direction))
                         .setSentAt(message.created.toEpochSecond(ZoneOffset.UTC) * 1000)
                         .setContent(message.message)
                         .build()

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessageToEmployer.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessageToEmployer.kt
@@ -1,0 +1,70 @@
+package com.linkedout.messaging.function.messages
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.messaging.service.MessageChannelService
+import com.linkedout.messaging.service.MessageService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.models.MessageOuterClass
+import com.linkedout.proto.services.Messaging.SendMessageToEmployerResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import java.time.ZoneOffset
+import java.util.*
+import java.util.function.Function
+
+@Component
+class SendMessageToEmployer(
+    private val messageService: MessageService,
+    private val messageChannelService: MessageChannelService
+) : Function<Request, Response> {
+    override fun apply(t: Request): Response {
+        // Extract the request
+        val request = t.sendMessageToEmployerRequest
+        val userId = UUID.fromString(request.userId)
+        val employerId = UUID.fromString(request.employerId)
+
+        // Ensure that the message channel exists in the database
+        val messageChannel = try {
+            messageChannelService.ensureExists(userId, employerId)
+                .block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Message channel could not be created").build()
+
+        // Insert the message into the database
+        val responseMono = try {
+            messageService.saveMessage(userId, messageChannel.id, request.content, 0)
+                .map { message ->
+                    MessageOuterClass.Message.newBuilder()
+                        .setId(message.id.toString())
+                        .setDirectionValue(message.direction)
+                        .setSentAt(message.created.toEpochSecond(ZoneOffset.UTC) * 1000)
+                        .setContent(message.message)
+                        .build()
+                }
+                .map { builder ->
+                    SendMessageToEmployerResponse.newBuilder()
+                        .setMessageChannelId(messageChannel.id.toString())
+                        .setEmployerId(messageChannel.employerId.toString())
+                        .setMessage(builder)
+                        .build()
+                }
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+
+        // Block until the response is ready
+        val response = try {
+            responseMono.block()
+        } catch (e: Exception) {
+            return RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()
+        }
+            ?: return RequestResponseFactory.newFailedResponse("Unable to send the message", HttpStatus.INTERNAL_SERVER_ERROR).build()
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setSendMessageToEmployerResponse(response)
+            .build()
+    }
+}

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessageToEmployer.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/function/messages/SendMessageToEmployer.kt
@@ -3,6 +3,7 @@ package com.linkedout.messaging.function.messages
 import com.linkedout.common.utils.RequestResponseFactory
 import com.linkedout.messaging.service.MessageChannelService
 import com.linkedout.messaging.service.MessageService
+import com.linkedout.messaging.utils.MessageDirection
 import com.linkedout.proto.RequestOuterClass.Request
 import com.linkedout.proto.ResponseOuterClass.Response
 import com.linkedout.proto.models.MessageOuterClass
@@ -35,11 +36,11 @@ class SendMessageToEmployer(
 
         // Insert the message into the database
         val responseMono = try {
-            messageService.saveMessage(userId, messageChannel.id, request.content, 0)
+            messageService.saveMessage(userId, messageChannel.id, request.content, MessageDirection.ToEmployer)
                 .map { message ->
                     MessageOuterClass.Message.newBuilder()
                         .setId(message.id.toString())
-                        .setDirectionValue(message.direction)
+                        .setDirection(MessageDirection.toProto(message.direction))
                         .setSentAt(message.created.toEpochSecond(ZoneOffset.UTC) * 1000)
                         .setContent(message.message)
                         .build()

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/Message.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/Message.kt
@@ -1,5 +1,6 @@
 package com.linkedout.messaging.model
 
+import com.linkedout.messaging.utils.MessageDirection
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Table
@@ -12,7 +13,7 @@ data class Message(
     val id: UUID,
     @Column("messagechannelid")
     val messageChannelId: UUID,
-    val direction: Int,
+    val direction: MessageDirection,
     val message: String,
     val created: LocalDateTime
 )

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/MessageChannelWithLastMessage.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/model/MessageChannelWithLastMessage.kt
@@ -1,0 +1,16 @@
+package com.linkedout.messaging.model
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import java.util.UUID
+
+data class MessageChannelWithLastMessage(
+    @Id
+    val id: UUID,
+    @Column("seasonworkerid")
+    val seasonworkerId: UUID,
+    @Column("employerid")
+    val employerId: UUID,
+    @Column("lastmessage")
+    val lastMessage: String?
+)

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
@@ -33,4 +33,13 @@ interface MessageChannelRepository : ReactiveCrudRepository<MessageChannel, UUID
     """
     )
     fun findOneWithSeasonworkerIdAndEmployerId(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel>
+
+    @Query(
+        """
+        INSERT INTO messagechannel (seasonworkerid, employerid)
+        VALUES (:seasonworkerId, :employerId)
+        RETURNING *
+    """
+    )
+    fun saveChannel(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel>
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageChannelRepository.kt
@@ -24,4 +24,13 @@ interface MessageChannelRepository : ReactiveCrudRepository<MessageChannel, UUID
     """
     )
     fun findOneWithSeasonworkerId(seasonworkerId: UUID, messageChannelId: UUID): Mono<MessageChannel>
+
+    @Query(
+        """
+        SELECT * FROM messagechannel
+        WHERE seasonworkerid = :seasonworkerId
+        AND employerid = :employerId
+    """
+    )
+    fun findOneWithSeasonworkerIdAndEmployerId(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel>
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageRepository.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/repository/MessageRepository.kt
@@ -4,6 +4,7 @@ import com.linkedout.messaging.model.Message
 import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.util.UUID
 
 interface MessageRepository : ReactiveCrudRepository<Message, UUID> {
@@ -16,4 +17,24 @@ interface MessageRepository : ReactiveCrudRepository<Message, UUID> {
     """
     )
     fun findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId: UUID, messageChannelId: UUID): Flux<Message>
+
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM messagechannel 
+            WHERE id = :messageChannelId
+            AND seasonworkerid = :seasonworkerId
+        )
+    """
+    )
+    fun existsWithSeasonworkerIdAndMessageChannelId(seasonworkerId: UUID, messageChannelId: UUID): Mono<Boolean>
+
+    @Query(
+        """
+        INSERT INTO message (messagechannelid, message, direction)
+        VALUES (:messageChannelId, :content, :direction)
+        RETURNING *
+    """
+    )
+    fun saveMessage(messageChannelId: UUID, content: String, direction: Int): Mono<Message>
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
@@ -20,4 +20,9 @@ class MessageChannelService(private val messageChannelRepository: MessageChannel
     fun findOneWithSeasonworkerIdAndEmployerId(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel> {
         return messageChannelRepository.findOneWithSeasonworkerIdAndEmployerId(seasonworkerId, employerId)
     }
+
+    fun ensureExists(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel> {
+        return messageChannelRepository.findOneWithSeasonworkerIdAndEmployerId(seasonworkerId, employerId)
+            .switchIfEmpty(messageChannelRepository.saveChannel(seasonworkerId, employerId))
+    }
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
@@ -16,4 +16,8 @@ class MessageChannelService(private val messageChannelRepository: MessageChannel
     fun findOneWithSeasonworkerId(seasonworkerId: UUID, messageChannelId: UUID): Mono<MessageChannel> {
         return messageChannelRepository.findOneWithSeasonworkerId(seasonworkerId, messageChannelId)
     }
+
+    fun findOneWithSeasonworkerIdAndEmployerId(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel> {
+        return messageChannelRepository.findOneWithSeasonworkerIdAndEmployerId(seasonworkerId, employerId)
+    }
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageChannelService.kt
@@ -1,6 +1,7 @@
 package com.linkedout.messaging.service
 
 import com.linkedout.messaging.model.MessageChannel
+import com.linkedout.messaging.model.MessageChannelWithLastMessage
 import com.linkedout.messaging.repository.MessageChannelRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
@@ -9,16 +10,16 @@ import java.util.UUID
 
 @Service
 class MessageChannelService(private val messageChannelRepository: MessageChannelRepository) {
-    fun findAllWithSeasonworkerId(seasonworkerId: UUID): Flux<MessageChannel> {
-        return messageChannelRepository.findAllWithSeasonworkerId(seasonworkerId)
+    fun findAllWithSeasonworkerId(seasonworkerId: UUID): Flux<MessageChannelWithLastMessage> {
+        return messageChannelRepository.findAllAndLastMessageWithSeasonworkerId(seasonworkerId)
     }
 
-    fun findOneWithSeasonworkerId(seasonworkerId: UUID, messageChannelId: UUID): Mono<MessageChannel> {
-        return messageChannelRepository.findOneWithSeasonworkerId(seasonworkerId, messageChannelId)
+    fun findOneWithSeasonworkerId(seasonworkerId: UUID, messageChannelId: UUID): Mono<MessageChannelWithLastMessage> {
+        return messageChannelRepository.findOneAndLastMessageWithSeasonworkerId(seasonworkerId, messageChannelId)
     }
 
-    fun findOneWithSeasonworkerIdAndEmployerId(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel> {
-        return messageChannelRepository.findOneWithSeasonworkerIdAndEmployerId(seasonworkerId, employerId)
+    fun findOneWithSeasonworkerIdAndEmployerId(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannelWithLastMessage> {
+        return messageChannelRepository.findOneAndLastMessageWithSeasonworkerIdAndEmployerId(seasonworkerId, employerId)
     }
 
     fun ensureExists(seasonworkerId: UUID, employerId: UUID): Mono<MessageChannel> {

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageService.kt
@@ -2,6 +2,7 @@ package com.linkedout.messaging.service
 
 import com.linkedout.messaging.model.Message
 import com.linkedout.messaging.repository.MessageRepository
+import com.linkedout.messaging.utils.MessageDirection
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -13,12 +14,12 @@ class MessageService(private val messageRepository: MessageRepository) {
         return messageRepository.findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId, messageChannelId)
     }
 
-    fun saveMessage(seasonworkerId: UUID, messageChannelId: UUID, content: String, direction: Int): Mono<Message> {
+    fun saveMessage(seasonworkerId: UUID, messageChannelId: UUID, content: String, direction: MessageDirection): Mono<Message> {
         // Ensure that the seasonworker is a member of the message channel
         if (messageRepository.existsWithSeasonworkerIdAndMessageChannelId(seasonworkerId, messageChannelId).block() != true) {
             throw Exception("Seasonworker is not a member of the message channel")
         }
 
-        return messageRepository.saveMessage(messageChannelId, content, direction)
+        return messageRepository.saveMessage(messageChannelId, content, direction.ordinal)
     }
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageService.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/service/MessageService.kt
@@ -4,11 +4,21 @@ import com.linkedout.messaging.model.Message
 import com.linkedout.messaging.repository.MessageRepository
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.util.UUID
 
 @Service
 class MessageService(private val messageRepository: MessageRepository) {
     fun findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId: UUID, messageChannelId: UUID): Flux<Message> {
         return messageRepository.findAllWithSeasonworkerIdAndMessageChannelId(seasonworkerId, messageChannelId)
+    }
+
+    fun saveMessage(seasonworkerId: UUID, messageChannelId: UUID, content: String, direction: Int): Mono<Message> {
+        // Ensure that the seasonworker is a member of the message channel
+        if (messageRepository.existsWithSeasonworkerIdAndMessageChannelId(seasonworkerId, messageChannelId).block() != true) {
+            throw Exception("Seasonworker is not a member of the message channel")
+        }
+
+        return messageRepository.saveMessage(messageChannelId, content, direction)
     }
 }

--- a/backend/messaging/src/main/kotlin/com/linkedout/messaging/utils/MessageDirection.kt
+++ b/backend/messaging/src/main/kotlin/com/linkedout/messaging/utils/MessageDirection.kt
@@ -1,0 +1,25 @@
+package com.linkedout.messaging.utils
+
+import com.linkedout.proto.models.MessageOuterClass.Message
+
+enum class MessageDirection {
+    ToEmployer,
+    ToSeasonworker;
+
+    companion object {
+        fun fromProto(value: Message.Direction): MessageDirection {
+            return when (value) {
+                Message.Direction.ToEmployer -> ToEmployer
+                Message.Direction.ToSeasonworker -> ToSeasonworker
+                else -> throw Exception("Invalid message direction")
+            }
+        }
+
+        fun toProto(value: MessageDirection): Message.Direction {
+            return when (value) {
+                ToEmployer -> Message.Direction.ToEmployer
+                ToSeasonworker -> Message.Direction.ToSeasonworker
+            }
+        }
+    }
+}

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser
+spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser;sendMessage
 
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.destination=messaging.findAllChannelsOfUser
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.group=messagingSvc
@@ -26,5 +26,14 @@ spring.cloud.stream.bindings.getMessagesOfUser-out-0.destination=
 spring.cloud.stream.bindings.getMessagesOfUser-out-0.group=messagingSvc
 spring.cloud.stream.bindings.getMessagesOfUser-out-0.binder=nats
 spring.cloud.stream.bindings.getMessagesOfUser-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.sendMessage-in-0.destination=messaging.sendMessage
+spring.cloud.stream.bindings.sendMessage-in-0.group=messagingSvc
+spring.cloud.stream.bindings.sendMessage-in-0.binder=nats
+spring.cloud.stream.bindings.sendMessage-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.sendMessage-out-0.destination=
+spring.cloud.stream.bindings.sendMessage-out-0.group=messagingSvc
+spring.cloud.stream.bindings.sendMessage-out-0.binder=nats
+spring.cloud.stream.bindings.sendMessage-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser;sendMessage;getChannelOfUserWithEmployer
+spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser;sendMessage;getChannelOfUserWithEmployer;sendMessageToEmployer
 
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.destination=messaging.findAllChannelsOfUser
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.group=messagingSvc
@@ -44,5 +44,14 @@ spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.destination=
 spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.group=messagingSvc
 spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.binder=nats
 spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.sendMessageToEmployer-in-0.destination=messaging.sendMessageToEmployer
+spring.cloud.stream.bindings.sendMessageToEmployer-in-0.group=messagingSvc
+spring.cloud.stream.bindings.sendMessageToEmployer-in-0.binder=nats
+spring.cloud.stream.bindings.sendMessageToEmployer-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.sendMessageToEmployer-out-0.destination=
+spring.cloud.stream.bindings.sendMessageToEmployer-out-0.group=messagingSvc
+spring.cloud.stream.bindings.sendMessageToEmployer-out-0.binder=nats
+spring.cloud.stream.bindings.sendMessageToEmployer-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/application.properties
+++ b/backend/messaging/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser;sendMessage
+spring.cloud.function.definition=getChannelsOfUser;getChannelOfUser;getMessagesOfUser;sendMessage;getChannelOfUserWithEmployer
 
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.destination=messaging.findAllChannelsOfUser
 spring.cloud.stream.bindings.getChannelsOfUser-in-0.group=messagingSvc
@@ -35,5 +35,14 @@ spring.cloud.stream.bindings.sendMessage-out-0.destination=
 spring.cloud.stream.bindings.sendMessage-out-0.group=messagingSvc
 spring.cloud.stream.bindings.sendMessage-out-0.binder=nats
 spring.cloud.stream.bindings.sendMessage-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-in-0.destination=messaging.findOneChannelOfUserWithEmployer
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-in-0.group=messagingSvc
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-in-0.binder=nats
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.destination=
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.group=messagingSvc
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.binder=nats
+spring.cloud.stream.bindings.getChannelOfUserWithEmployer-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
+++ b/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
@@ -1,6 +1,5 @@
 CREATE TABLE MessageChannel (
                                 id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                                 seasonworkerId UUID NOT NULL,
-                                employerId UUID NOT NULL,
-                                CONSTRAINT u_message_channel UNIQUE (seasonworkerId, employerId)
+                                employerId UUID NOT NULL
 );

--- a/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
+++ b/backend/messaging/src/main/resources/db/migration/V1__initial_state.sql
@@ -1,5 +1,6 @@
 CREATE TABLE MessageChannel (
                                 id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                                 seasonworkerId UUID NOT NULL,
-                                employerId UUID NOT NULL
+                                employerId UUID NOT NULL,
+                                CONSTRAINT u_message_channel UNIQUE (seasonworkerId, employerId)
 );

--- a/backend/messaging/src/main/resources/db/migration/V3__unique_seasonworker_employer_couple_on_channels.sql
+++ b/backend/messaging/src/main/resources/db/migration/V3__unique_seasonworker_employer_couple_on_channels.sql
@@ -1,0 +1,2 @@
+ALTER TABLE MessageChannel
+ADD CONSTRAINT u_message_channel UNIQUE (seasonworkerId, employerId);

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -19,5 +19,6 @@ message Request {
     services.GetMultipleEmployersRequest get_multiple_employers_request = 8;
     services.GetUserMessagesRequest get_user_messages_request = 9;
     services.SendMessageRequest send_message_request = 10;
+    services.GetUserMessageChannelWithEmployerRequest get_user_message_channel_with_employer_request = 11;
   }
 }

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -20,5 +20,6 @@ message Request {
     services.GetUserMessagesRequest get_user_messages_request = 9;
     services.SendMessageRequest send_message_request = 10;
     services.GetUserMessageChannelWithEmployerRequest get_user_message_channel_with_employer_request = 11;
+    services.SendMessageToEmployerRequest send_message_to_employer_request = 12;
   }
 }

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -18,5 +18,6 @@ message Request {
     services.GetEmployerRequest get_employer_request = 7;
     services.GetMultipleEmployersRequest get_multiple_employers_request = 8;
     services.GetUserMessagesRequest get_user_messages_request = 9;
+    services.SendMessageRequest send_message_request = 10;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -24,5 +24,6 @@ message Response {
     services.GetEmployerResponse get_employer_response = 8;
     services.GetMultipleEmployersResponse get_multiple_employers_response = 9;
     services.GetUserMessagesResponse get_user_messages_response = 10;
+    services.SendMessageResponse send_message_response = 11;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -26,5 +26,6 @@ message Response {
     services.GetUserMessagesResponse get_user_messages_response = 10;
     services.SendMessageResponse send_message_response = 11;
     services.GetUserMessageChannelWithEmployerResponse get_user_message_channel_with_employer_response = 12;
+    services.SendMessageToEmployerResponse send_message_to_employer_response = 13;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -25,5 +25,6 @@ message Response {
     services.GetMultipleEmployersResponse get_multiple_employers_response = 9;
     services.GetUserMessagesResponse get_user_messages_response = 10;
     services.SendMessageResponse send_message_response = 11;
+    services.GetUserMessageChannelWithEmployerResponse get_user_message_channel_with_employer_response = 12;
   }
 }

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -34,3 +34,17 @@ message GetUserMessagesResponse {
     string employer_id = 2;
     repeated models.Message messages = 3;
 }
+
+// Send a message to a message channel
+message SendMessageRequest {
+    string user_id = 1;
+    string message_channel_id = 2;
+    string content = 3;
+    models.Message.Direction direction = 4;
+}
+
+message SendMessageResponse {
+    string message_channel_id = 1;
+    string employer_id = 2;
+    models.Message message = 3;
+}

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -58,3 +58,16 @@ message GetUserMessageChannelWithEmployerRequest {
 message GetUserMessageChannelWithEmployerResponse {
     models.MessageChannel message_channel = 1;
 }
+
+// Send a message to an employer
+message SendMessageToEmployerRequest {
+    string user_id = 1;
+    string employer_id = 2;
+    string content = 3;
+}
+
+message SendMessageToEmployerResponse {
+    string message_channel_id = 1;
+    string employer_id = 2;
+    models.Message message = 3;
+}

--- a/backend/protobuf/src/main/proto/services/messaging.proto
+++ b/backend/protobuf/src/main/proto/services/messaging.proto
@@ -48,3 +48,13 @@ message SendMessageResponse {
     string employer_id = 2;
     models.Message message = 3;
 }
+
+// Get a message channel of a user with a specific employer
+message GetUserMessageChannelWithEmployerRequest {
+    string user_id = 1;
+    string employer_id = 2;
+}
+
+message GetUserMessageChannelWithEmployerResponse {
+    models.MessageChannel message_channel = 1;
+}


### PR DESCRIPTION
The following methods were implemented to be used through the message broker:

- `sendMessage` : sends a message to the specified message channel, corresponds to the `POST /messaging/{messageChannelId}/messages` API route
- `findOneChannelOfUserWithEmployer` : gets the messaging channel between a seasonworker and an employer, corresponds to the `GET /employers/{employerId}/messaging` API route
- `sendMessageToEmployer` : sends a message to the specified employer, corresponds to the `POST /employers/{employerId}/messaging` API route

## Other changes

An enum has been created to list the possible message directions.

A constraint has been added to the `MessageChannel` table to ensure that a single `(seasonworkerId, employerId)` couple exists.

The last message of a channel is now sent when requesting message channels.