### PR TITLE
feat(profile): implement profile picture and cv routes

### DIFF
--- a/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/ProfileController.kt
+++ b/backend/api_gateway/src/main/kotlin/com/linkedout/backend/controller/ProfileController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -68,5 +69,47 @@ class ProfileController(
     ): Mono<Unit> {
         profileService.deleteOne(request.id, profileId)
         return Mono.empty()
+    }
+
+    @PostMapping("/cv")
+    open fun uploadCv(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @RequestPart file: ByteArray
+    ): Mono<Unit> {
+        profileService.setOneCv(request.id, principal.name, file)
+        return Mono.empty()
+    }
+
+    @GetMapping(
+        value = ["/cv"],
+        produces = ["application/pdf"]
+    )
+    open fun downloadCv(
+        request: ServerHttpRequest,
+        principal: Principal
+    ): Mono<ByteArray> {
+        return Mono.just(profileService.findOneCv(request.id, principal.name))
+    }
+
+    @PostMapping("/photo")
+    open fun uploadPhoto(
+        request: ServerHttpRequest,
+        principal: Principal,
+        @RequestPart file: ByteArray
+    ): Mono<Unit> {
+        profileService.setOneProfilePicture(request.id, principal.name, file)
+        return Mono.empty()
+    }
+
+    @GetMapping(
+        value = ["/photo"],
+        produces = ["image/png"]
+    )
+    open fun downloadPhoto(
+        request: ServerHttpRequest,
+        principal: Principal
+    ): Mono<ByteArray> {
+        return Mono.just(profileService.findOneProfilePicture(request.id, principal.name))
     }
 }

--- a/backend/api_gateway/src/main/resources/application.yml
+++ b/backend/api_gateway/src/main/resources/application.yml
@@ -66,6 +66,10 @@ app:
         requestDeletionOfUser: profile.requestProfileDeletionOfUser
         saveOneOfUser: profile.saveOneOfUser
         updateOneOfUser: profile.updateOneOfUser
+        findOneCvOfUser: profile.findOneCvOfUser
+        saveOneCvOfUser: profile.saveOneCvOfUser
+        findOneProfilePictureOfUser: profile.findOneProfilePictureOfUser
+        saveOneProfilePictureOfUser: profile.saveOneProfilePictureOfUser
     availability:
       subjects:
         createOneOfUser: availability.createOneOfUser

--- a/backend/common/src/main/kotlin/com/linkedout/common/utils/CloudStreamErrorHandler.kt
+++ b/backend/common/src/main/kotlin/com/linkedout/common/utils/CloudStreamErrorHandler.kt
@@ -1,10 +1,14 @@
 package com.linkedout.common.utils
 
 import com.linkedout.proto.ResponseOuterClass.Response
+import org.springframework.web.ErrorResponseException
 
 inline fun handleRequestError(block: () -> Response): Response {
     return try {
         block()
+    } catch (e: ErrorResponseException) {
+        e.printStackTrace()
+        RequestResponseFactory.newFailedResponse(e.message, e.statusCode).build()
     } catch (e: Throwable) {
         e.printStackTrace()
         RequestResponseFactory.newFailedResponse(e.message ?: "Unknown error").build()

--- a/backend/common/src/main/kotlin/com/linkedout/common/utils/RequestResponseFactory.kt
+++ b/backend/common/src/main/kotlin/com/linkedout/common/utils/RequestResponseFactory.kt
@@ -3,6 +3,7 @@ package com.linkedout.common.utils
 import com.linkedout.proto.RequestOuterClass
 import com.linkedout.proto.ResponseOuterClass
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 
 class RequestResponseFactory private constructor() {
     companion object {
@@ -15,7 +16,7 @@ class RequestResponseFactory private constructor() {
             return ResponseOuterClass.Response.newBuilder()
         }
 
-        fun newFailedResponse(message: String, errorCode: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR): ResponseOuterClass.Response.Builder {
+        fun newFailedResponse(message: String, errorCode: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR): ResponseOuterClass.Response.Builder {
             return ResponseOuterClass.Response.newBuilder()
                 .setError(
                     ResponseOuterClass.Error.newBuilder()

--- a/backend/profile/build.gradle.kts
+++ b/backend/profile/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.postgresql:r2dbc-postgresql:1.0.2.RELEASE")
     implementation("jakarta.validation:jakarta.validation-api:3.0.2")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.20")
+    implementation("io.minio:minio:8.5.7")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/config/S3ClientConfiguration.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/config/S3ClientConfiguration.kt
@@ -1,0 +1,18 @@
+package com.linkedout.profile.config
+
+import io.minio.MinioClient
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(S3ClientConfigurationProperties::class)
+class S3ClientConfiguration {
+    @Bean
+    fun s3Client(s3props: S3ClientConfigurationProperties): MinioClient {
+        return MinioClient.builder()
+            .endpoint(s3props.endpoint)
+            .credentials(s3props.accessKey, s3props.secretKey)
+            .build()
+    }
+}

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/config/S3ClientConfigurationProperties.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/config/S3ClientConfigurationProperties.kt
@@ -1,0 +1,13 @@
+package com.linkedout.profile.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.net.URL
+
+@ConfigurationProperties(prefix = "s3")
+data class S3ClientConfigurationProperties(
+    val endpoint: URL,
+    val accessKey: String,
+    val secretKey: String,
+    val bucket: String,
+    val multipartMinPartSize: Long = 5 * 1024 * 1024
+)

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/GetCvOfUser.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/GetCvOfUser.kt
@@ -1,0 +1,32 @@
+package com.linkedout.profile.function.attachment
+
+import com.google.protobuf.ByteString
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.common.utils.handleRequestError
+import com.linkedout.profile.service.AttachmentService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.services.Profile.GetUserCvResponse
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.function.Function
+
+@Component
+class GetCvOfUser(private val attachmentService: AttachmentService) : Function<Request, Response> {
+    override fun apply(t: Request): Response = handleRequestError {
+        // Extract the request
+        val request = t.getUserCvRequest
+        val userId = UUID.fromString(request.userId)
+
+        // Download the CV
+        val cv = attachmentService.findCvOfUser(userId)
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetUserCvResponse(
+                GetUserCvResponse.newBuilder()
+                    .setCv(ByteString.copyFrom(cv))
+                    .build()
+            )
+            .build()
+    }
+}

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/GetProfilePictureOfUser.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/GetProfilePictureOfUser.kt
@@ -1,0 +1,32 @@
+package com.linkedout.profile.function.attachment
+
+import com.google.protobuf.ByteString
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.common.utils.handleRequestError
+import com.linkedout.profile.service.AttachmentService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.services.Profile
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.function.Function
+
+@Component
+class GetProfilePictureOfUser(private val attachmentService: AttachmentService) : Function<Request, Response> {
+    override fun apply(t: Request): Response = handleRequestError {
+        // Extract the request
+        val request = t.getUserProfilePictureRequest
+        val userId = UUID.fromString(request.userId)
+
+        // Download the profile picture
+        val profilePicture = attachmentService.findProfilePictureOfUser(userId)
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setGetUserProfilePictureResponse(
+                Profile.GetUserProfilePictureResponse.newBuilder()
+                    .setPicture(ByteString.copyFrom(profilePicture))
+                    .build()
+            )
+            .build()
+    }
+}

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/SetCvOfUser.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/SetCvOfUser.kt
@@ -1,0 +1,28 @@
+package com.linkedout.profile.function.attachment
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.common.utils.handleRequestError
+import com.linkedout.profile.service.AttachmentService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.services.Profile
+import org.springframework.stereotype.Component
+import java.util.*
+import java.util.function.Function
+
+@Component
+class SetCvOfUser(private val attachmentService: AttachmentService) : Function<Request, Response> {
+    override fun apply(t: Request): Response = handleRequestError {
+        // Extract the request
+        val request = t.setUserCvRequest
+        val userId = UUID.fromString(request.userId)
+        val cv = request.cv.toByteArray()
+
+        // Upload the CV
+        attachmentService.setCvOfUser(userId, cv)
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setSetUserCvResponse(Profile.SetUserCvResponse.getDefaultInstance())
+            .build()
+    }
+}

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/SetProfilePictureOfUser.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/function/attachment/SetProfilePictureOfUser.kt
@@ -1,0 +1,28 @@
+package com.linkedout.profile.function.attachment
+
+import com.linkedout.common.utils.RequestResponseFactory
+import com.linkedout.common.utils.handleRequestError
+import com.linkedout.profile.service.AttachmentService
+import com.linkedout.proto.RequestOuterClass.Request
+import com.linkedout.proto.ResponseOuterClass.Response
+import com.linkedout.proto.services.Profile
+import org.springframework.stereotype.Component
+import java.util.UUID
+import java.util.function.Function
+
+@Component
+class SetProfilePictureOfUser(private val attachmentService: AttachmentService) : Function<Request, Response> {
+    override fun apply(t: Request): Response = handleRequestError {
+        // Extract the request
+        val request = t.setUserProfilePictureRequest
+        val userId = UUID.fromString(request.userId)
+        val profilePicture = request.picture.toByteArray()
+
+        // Upload the profile picture
+        attachmentService.setProfilePictureOfUser(userId, profilePicture)
+
+        return RequestResponseFactory.newSuccessfulResponse()
+            .setSetUserProfilePictureResponse(Profile.SetUserProfilePictureResponse.getDefaultInstance())
+            .build()
+    }
+}

--- a/backend/profile/src/main/kotlin/com/linkedout/profile/service/AttachmentService.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/service/AttachmentService.kt
@@ -1,0 +1,64 @@
+package com.linkedout.profile.service
+
+import com.linkedout.profile.config.S3ClientConfigurationProperties
+import io.minio.GetObjectArgs
+import io.minio.MinioClient
+import io.minio.PutObjectArgs
+import io.minio.errors.ErrorResponseException
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import java.util.*
+
+@Service
+class AttachmentService(
+    private val s3Client: MinioClient,
+    private val s3ClientConfigurationProperties: S3ClientConfigurationProperties
+) {
+    fun findCvOfUser(userId: UUID): ByteArray {
+        return getObject("user:$userId/cv")
+    }
+
+    fun setCvOfUser(userId: UUID, cv: ByteArray) {
+        putObject("user:$userId/cv", cv, MediaType.APPLICATION_PDF_VALUE)
+    }
+
+    fun findProfilePictureOfUser(userId: UUID): ByteArray {
+        return getObject("user:$userId/profile-picture")
+    }
+
+    fun setProfilePictureOfUser(userId: UUID, profilePicture: ByteArray) {
+        putObject("user:$userId/profile-picture", profilePicture, MediaType.IMAGE_PNG_VALUE)
+    }
+
+    private fun getObject(key: String): ByteArray {
+        val data = try {
+            s3Client.getObject(
+                GetObjectArgs.builder()
+                    .bucket(s3ClientConfigurationProperties.bucket)
+                    .`object`(key)
+                    .build()
+            ).readAllBytes()
+        } catch (e: ErrorResponseException) {
+            throw ResponseStatusException(
+                HttpStatus.resolve(e.response().code) ?: HttpStatus.INTERNAL_SERVER_ERROR,
+                e.errorResponse().message(),
+                e
+            )
+        }
+
+        return data
+    }
+
+    private fun putObject(key: String, data: ByteArray, contentType: String) {
+        s3Client.putObject(
+            PutObjectArgs.builder()
+                .bucket(s3ClientConfigurationProperties.bucket)
+                .`object`(key)
+                .stream(data.inputStream(), data.size.toLong(), -1)
+                .contentType(contentType)
+                .build()
+        )
+    }
+}

--- a/backend/profile/src/main/resources/application.properties
+++ b/backend/profile/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cloud.function.definition=deleteProfile;getProfileOfUser;getProfilesRequestingDeletion;requestProfileDeletionOfUser;setProfileOfUser;updateProfileOfUser;createAvailabilityOfUser;deleteAvailabilityOfUser;getAvailabilitiesOfUser;getAvailabilityOfUser;updateAvailabilityOfUser;createReferenceOfUser;deleteReferenceOfUser;getReferencesOfUser;getReferenceOfUser;updateReferenceOfUser;createExperienceOfUser;deleteExperienceOfUser;getExperiencesOfUser;getExperienceOfUser;updateExperienceOfUser;getEvaluationsOfUser;getEvaluationOfUser
+spring.cloud.function.definition=deleteProfile;getProfileOfUser;getProfilesRequestingDeletion;requestProfileDeletionOfUser;setProfileOfUser;updateProfileOfUser;createAvailabilityOfUser;deleteAvailabilityOfUser;getAvailabilitiesOfUser;getAvailabilityOfUser;updateAvailabilityOfUser;createReferenceOfUser;deleteReferenceOfUser;getReferencesOfUser;getReferenceOfUser;updateReferenceOfUser;createExperienceOfUser;deleteExperienceOfUser;getExperiencesOfUser;getExperienceOfUser;updateExperienceOfUser;getEvaluationsOfUser;getEvaluationOfUser;getCvOfUser;setCvOfUser;getProfilePictureOfUser;setProfilePictureOfUser
 
 spring.cloud.stream.bindings.deleteProfile-in-0.destination=profile.deleteOne
 spring.cloud.stream.bindings.deleteProfile-in-0.group=profileSvc
@@ -206,5 +206,41 @@ spring.cloud.stream.bindings.getEvaluationOfUser-out-0.destination=
 spring.cloud.stream.bindings.getEvaluationOfUser-out-0.group=profileSvc
 spring.cloud.stream.bindings.getEvaluationOfUser-out-0.binder=nats
 spring.cloud.stream.bindings.getEvaluationOfUser-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.getCvOfUser-in-0.destination=profile.findOneCvOfUser
+spring.cloud.stream.bindings.getCvOfUser-in-0.group=profileSvc
+spring.cloud.stream.bindings.getCvOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.getCvOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getCvOfUser-out-0.destination=
+spring.cloud.stream.bindings.getCvOfUser-out-0.group=profileSvc
+spring.cloud.stream.bindings.getCvOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.getCvOfUser-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.setCvOfUser-in-0.destination=profile.saveOneCvOfUser
+spring.cloud.stream.bindings.setCvOfUser-in-0.group=profileSvc
+spring.cloud.stream.bindings.setCvOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.setCvOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.setCvOfUser-out-0.destination=
+spring.cloud.stream.bindings.setCvOfUser-out-0.group=profileSvc
+spring.cloud.stream.bindings.setCvOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.setCvOfUser-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.getProfilePictureOfUser-in-0.destination=profile.findOneProfilePictureOfUser
+spring.cloud.stream.bindings.getProfilePictureOfUser-in-0.group=profileSvc
+spring.cloud.stream.bindings.getProfilePictureOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.getProfilePictureOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.getProfilePictureOfUser-out-0.destination=
+spring.cloud.stream.bindings.getProfilePictureOfUser-out-0.group=profileSvc
+spring.cloud.stream.bindings.getProfilePictureOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.getProfilePictureOfUser-out-0.content-type=application/vnd.linkedout.proto-response
+
+spring.cloud.stream.bindings.setProfilePictureOfUser-in-0.destination=profile.saveOneProfilePictureOfUser
+spring.cloud.stream.bindings.setProfilePictureOfUser-in-0.group=profileSvc
+spring.cloud.stream.bindings.setProfilePictureOfUser-in-0.binder=nats
+spring.cloud.stream.bindings.setProfilePictureOfUser-in-0.content-type=application/vnd.linkedout.proto-request
+spring.cloud.stream.bindings.setProfilePictureOfUser-out-0.destination=
+spring.cloud.stream.bindings.setProfilePictureOfUser-out-0.group=profileSvc
+spring.cloud.stream.bindings.setProfilePictureOfUser-out-0.binder=nats
+spring.cloud.stream.bindings.setProfilePictureOfUser-out-0.content-type=application/vnd.linkedout.proto-response
 
 nats.spring.server=nats://localhost:4222

--- a/backend/profile/src/main/resources/application.yml
+++ b/backend/profile/src/main/resources/application.yml
@@ -11,3 +11,7 @@ spring:
 
 server:
   port: 8085
+
+s3:
+  endpoint: https://s3-api.linkedout.cluster-2020-5.dopolytech.fr/
+  bucket: linkedout

--- a/backend/protobuf/src/main/proto/request.proto
+++ b/backend/protobuf/src/main/proto/request.proto
@@ -63,5 +63,9 @@ message Request {
     services.CreateEmployerEvaluationRequest create_employer_evaluation_request = 50;
     services.GetEmployerEvaluationRequest get_employer_evaluation_request = 51;
     services.DeleteEmployerEvaluationRequest delete_employer_evaluation_request = 52;
+    services.GetUserProfilePictureRequest get_user_profile_picture_request = 53;
+    services.SetUserProfilePictureRequest set_user_profile_picture_request = 54;
+    services.GetUserCvRequest get_user_cv_request = 55;
+    services.SetUserCvRequest set_user_cv_request = 56;
   }
 }

--- a/backend/protobuf/src/main/proto/response.proto
+++ b/backend/protobuf/src/main/proto/response.proto
@@ -67,5 +67,9 @@ message Response {
     services.CreateEmployerEvaluationResponse create_employer_evaluation_response = 49;
     services.GetEmployerEvaluationResponse get_employer_evaluation_response = 50;
     services.DeleteEmployerEvaluationResponse delete_employer_evaluation_response = 51;
+    services.GetUserProfilePictureResponse get_user_profile_picture_response = 52;
+    services.SetUserProfilePictureResponse set_user_profile_picture_response = 53;
+    services.GetUserCvResponse get_user_cv_response = 54;
+    services.SetUserCvResponse set_user_cv_response = 55;
   }
 }

--- a/backend/protobuf/src/main/proto/services/profile.proto
+++ b/backend/protobuf/src/main/proto/services/profile.proto
@@ -230,3 +230,37 @@ message GetUserEvaluationRequest {
 message GetUserEvaluationResponse {
   models.EmployeeEvaluation evaluation = 1;
 }
+
+// Get the profile picture of a user
+message GetUserProfilePictureRequest {
+  string user_id = 1;
+}
+
+message GetUserProfilePictureResponse {
+  bytes picture = 1;
+}
+
+// Set the profile picture of a user
+message SetUserProfilePictureRequest {
+  string user_id = 1;
+  bytes picture = 2;
+}
+
+message SetUserProfilePictureResponse {}
+
+// Get the CV of a user
+message GetUserCvRequest {
+  string user_id = 1;
+}
+
+message GetUserCvResponse {
+  bytes cv = 1;
+}
+
+// Set the CV of a user
+message SetUserCvRequest {
+  string user_id = 1;
+  bytes cv = 2;
+}
+
+message SetUserCvResponse {}


### PR DESCRIPTION
This implements the functions in the `profile` service to store attachments (profile picture, CV) to a profile. The following methods were implemented to be used through the message broker:

- `findOneCvOfUser` : gets the CV of a user, corresponds to the `GET /profile/cv` API route
- `saveOneCvOfUser` : sets the CV of a user, corresponds to the `POST /profile/cv` API route
- `findOneProfilePictureOfUser` : gets the profile picture of a user, corresponds to the `GET /profile/photo` API route
- `saveOneProfilePictureOfUser` : sets the profile picture of a user, corresponds to the `POST /profile/photo` API route

The attachments are stored in an S3-compatible object storage that can be configured in the `profile` service configuration.