### PR TITLE
fix(docker): copy the correct jar file

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,13 +11,13 @@ COPY ./gradle.properties .
 COPY ./gradlew .
 COPY ./settings.gradle.kts .
 
-RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build -x test
+RUN --mount=type=cache,target=/root/.gradle ./gradlew clean bootJar
 
 # Run stage
 FROM amazoncorretto:17-alpine AS run
 ARG SERVICE_NAME
 WORKDIR /app
 
-COPY --from=build /app/$SERVICE_NAME/build/libs/*-SNAPSHOT.jar ./app.jar
+COPY --from=build /app/$SERVICE_NAME/build/libs/$SERVICE_NAME.jar ./app.jar
 
 ENTRYPOINT ["java", "-jar", "./app.jar"]


### PR DESCRIPTION
This fixes the backend container images by correcting the JAR file name that is copied into the last stage.