### PR TITLE
fix(profile): set default value for the average rating

### DIFF
--- a/backend/profile/src/main/kotlin/com/linkedout/profile/repository/ProfileRepository.kt
+++ b/backend/profile/src/main/kotlin/com/linkedout/profile/repository/ProfileRepository.kt
@@ -116,9 +116,9 @@ interface ProfileRepository : ReactiveCrudRepository<Profile, UUID> {
        (SELECT COUNT(*)
         FROM evaluation
         WHERE user_id = :userId) as nb_reviews,
-       (SELECT AVG(score)
+        COALESCE((SELECT AVG(score)
         FROM evaluation
-        WHERE user_id = :userId) as avg_rating;
+        WHERE user_id = :userId), 0) as avg_rating;
     """
     )
     fun getProfileStatsOfUser(userId: UUID): Mono<ProfileStats>


### PR DESCRIPTION
This sets a default value for the average rating returned by the `GET /profile` route if the user has no evaluation yet.