### PR TITLE
feat(front): improve employer messaging and evaluation

### DIFF
--- a/front/assets/translations/en_US.json
+++ b/front/assets/translations/en_US.json
@@ -14,12 +14,18 @@
     "evaluation": "Employer evaluation",
     "giveAReview": "Give a review",
     "review": "Describe your experience at this job",
-    "sendEvaluation": "Send my evaluation"
+    "sendEvaluation": "Send my evaluation",
+    "deleteEvaluation": {
+      "button": "Delete my evaluation",
+      "title": "Delete evaluation",
+      "message": "Are you sure you want to delete your evaluation?"
+    }
   },
   "jobOffer": {
     "info": {
       "jobOfferList": "Job offer list",
-      "jobOffer": "Job offer"
+      "jobOffer": "Job offer",
+      "employerInfo": "See employer information"
     },
     "apply": {
       "apply": "Apply",

--- a/front/assets/translations/fr_FR.json
+++ b/front/assets/translations/fr_FR.json
@@ -14,12 +14,18 @@
     "evaluation": "Avis sur l'employeur",
     "giveAReview": "Donnez un avis",
     "review": "Decrivez votre expérience à ce job",
-    "sendEvaluation": "Envoyer mon avis"
+    "sendEvaluation": "Envoyer mon avis",
+    "deleteEvaluation": {
+      "button": "Supprimer mon avis",
+      "title": "Suppression de l'avis",
+      "message": "Voulez-vous vraiment supprimer votre avis ?"
+    }
   },
   "jobOffer": {
     "info": {
       "jobOfferList": "Liste des offres d'emploi",
-      "jobOffer": "Offre d'emploi"
+      "jobOffer": "Offre d'emploi",
+      "employerInfo": "Voir le profil de l'employeur"
     },
     "apply": {
       "apply": "Postuler",

--- a/front/src/components/employer/EmployerEvaluationContent.tsx
+++ b/front/src/components/employer/EmployerEvaluationContent.tsx
@@ -1,0 +1,132 @@
+import { FC, useCallback, useState } from 'react';
+import { Alert, Image, StyleSheet, View } from 'react-native';
+import { Button, Text } from 'react-native-paper';
+
+import EmployerEvaluationForm, {
+  EmployerEvaluationFormData,
+} from '@/components/employer/EmployerEvaluationForm';
+import { CreateEmployerEvaluationDto } from '@/models/dtos/employer/createEmployerEvaluationDto';
+import { Employer } from '@/models/entities/employer';
+import { EmployerEvaluation } from '@/models/entities/employerEvaluation';
+import {
+  useDeleteEmployerEvaluationMutation,
+  usePostEmployerEvaluationMutation,
+} from '@/store/api/employerApiSlice';
+import i18n from '@/utils/i18n';
+
+/**
+ * The styles for the EmployerEvaluationContent component.
+ */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 16,
+  },
+  nameContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+  },
+  profilePicture: {
+    borderRadius: 48,
+    height: 60,
+    width: 60,
+  },
+});
+
+/**
+ * The props for the EmployerEvaluationContent component.
+ */
+type EmployerEvaluationContentProps = {
+  /**
+   * The employer to evaluate.
+   */
+  employer: Employer;
+
+  /**
+   * The evaluation that was already given.
+   */
+  employerEvaluation?: EmployerEvaluation;
+};
+
+/**
+ * Displays the content for an employer evaluation page.
+ * @constructor
+ */
+export const EmployerEvaluationContent: FC<EmployerEvaluationContentProps> = ({
+  employer,
+  employerEvaluation,
+}) => {
+  // API calls
+  const [postEmployerEvaluation] = usePostEmployerEvaluationMutation();
+  const [deleteEmployerEvaluation] = useDeleteEmployerEvaluationMutation();
+
+  // State
+  const [formData, setFormData] = useState<EmployerEvaluationFormData>({
+    score: employerEvaluation?.score ?? 1,
+    review: employerEvaluation?.review ?? '',
+  });
+
+  // Callbacks
+  const handleSubmitEvaluation = useCallback(() => {
+    const newEvaluation: CreateEmployerEvaluationDto = {
+      id: employer.id,
+      evaluation: {
+        score: formData.score,
+        review: formData.review,
+      },
+    };
+
+    postEmployerEvaluation(newEvaluation);
+  }, [employer.id, formData.review, formData.score, postEmployerEvaluation]);
+
+  const handleDeleteEvaluation = useCallback(() => {
+    Alert.alert(
+      i18n.t('employer.deleteEvaluation.title'),
+      i18n.t('employer.deleteEvaluation.message'),
+      [
+        {
+          text: i18n.t('common.cancel'),
+          style: 'cancel',
+        },
+        {
+          text: i18n.t('common.delete'),
+          onPress: () => {
+            deleteEmployerEvaluation(employer.id);
+            setFormData({ score: 1, review: '' });
+          },
+          style: 'destructive',
+        },
+      ],
+    );
+  }, [deleteEmployerEvaluation, employer.id]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.nameContainer}>
+        <Image
+          style={styles.profilePicture}
+          source={{
+            uri: employer.picture,
+          }}
+        />
+
+        <View>
+          <Text variant='headlineMedium'>{`${employer.firstName} ${employer.lastName}`}</Text>
+        </View>
+      </View>
+
+      <EmployerEvaluationForm
+        formData={formData}
+        onFormDataUpdate={setFormData}
+        onSubmit={handleSubmitEvaluation}
+      />
+
+      <Button mode='contained-tonal' onPress={handleDeleteEvaluation}>
+        {i18n.t('employer.deleteEvaluation.button')}
+      </Button>
+    </View>
+  );
+};
+
+export default EmployerEvaluationContent;

--- a/front/src/components/employer/EmployerEvaluationForm.tsx
+++ b/front/src/components/employer/EmployerEvaluationForm.tsx
@@ -1,9 +1,8 @@
 import { FC, useCallback } from 'react';
-import { Image, StyleSheet, View } from 'react-native';
-import { Text, TextInput } from 'react-native-paper';
+import { StyleSheet, View } from 'react-native';
+import { Button, Text, TextInput } from 'react-native-paper';
 
 import StarRatingSelector from '@/components/utils/StarRatingSelector';
-import { Employer } from '@/models/entities/employer';
 import i18n from '@/utils/i18n';
 
 /**
@@ -11,20 +10,7 @@ import i18n from '@/utils/i18n';
  */
 const styles = StyleSheet.create({
   container: {
-    gap: 6,
-  },
-  nameContainer: {
-    alignItems: 'center',
-    flexDirection: 'row',
-    gap: 8,
-  },
-  profilePicture: {
-    borderRadius: 48,
-    height: 60,
-    width: 60,
-  },
-  textInput: {
-    marginVertical: 8,
+    gap: 12,
   },
 });
 
@@ -41,11 +27,6 @@ export type EmployerEvaluationFormData = {
  */
 type EmployerEvaluationFormProps = {
   /**
-   * The employer to evaluate.
-   */
-  employer: Employer;
-
-  /**
    * The data for the form.
    */
   formData: EmployerEvaluationFormData;
@@ -54,6 +35,11 @@ type EmployerEvaluationFormProps = {
    * The function to call when the form data is updated.
    */
   onFormDataUpdate: (data: EmployerEvaluationFormData) => void;
+
+  /**
+   * The function to call when the form is submitted.
+   */
+  onSubmit: () => void;
 };
 
 /**
@@ -61,9 +47,9 @@ type EmployerEvaluationFormProps = {
  * @constructor
  */
 const EmployerEvaluationForm: FC<EmployerEvaluationFormProps> = ({
-  employer,
   formData,
   onFormDataUpdate,
+  onSubmit,
 }) => {
   // Callbacks
   const handleInputChange = useCallback(
@@ -81,30 +67,23 @@ const EmployerEvaluationForm: FC<EmployerEvaluationFormProps> = ({
 
   return (
     <View style={styles.container}>
-      <View style={styles.nameContainer}>
-        <Image
-          style={styles.profilePicture}
-          source={{
-            uri: employer.picture,
-          }}
-        />
-        <View>
-          <Text variant='headlineMedium'>{`${employer.firstName} ${employer.lastName}`}</Text>
-        </View>
-      </View>
       <Text variant='titleLarge'> {i18n.t('employer.giveAReview')}</Text>
       <StarRatingSelector
         rating={formData.score}
         onStarPress={(value) => handleInputChange('score', value)}
       />
+
       <TextInput
         label={i18n.t('employer.review')}
         value={formData.review}
-        style={styles.textInput}
         multiline
         numberOfLines={6}
         onChangeText={(value) => handleInputChange('review', value)}
       />
+
+      <Button mode='contained' onPress={onSubmit}>
+        {i18n.t('employer.sendEvaluation')}
+      </Button>
     </View>
   );
 };

--- a/front/src/components/jobOffers/JobOfferContent.tsx
+++ b/front/src/components/jobOffers/JobOfferContent.tsx
@@ -51,6 +51,11 @@ type JobOfferContentProps = {
    * The function to call when a message has been sent.
    */
   onMessageSent?: (message: Message) => void;
+
+  /**
+   * The function to call when the user wants to see the employer's info.
+   */
+  onEmployerInfoClick?: () => void;
 };
 
 /**
@@ -60,6 +65,7 @@ type JobOfferContentProps = {
 const JobOfferContent: FC<JobOfferContentProps> = ({
   jobOffer,
   onMessageSent,
+  onEmployerInfoClick,
 }) => {
   // API calls
   const [applyToJobOffer] = usePostApplyJobOfferMutation();
@@ -143,10 +149,16 @@ const JobOfferContent: FC<JobOfferContentProps> = ({
       )}
 
       {jobOffer.status === JobOfferStatus.ACCEPTED && (
-        <JobOfferMessageSender
-          employerId={jobOffer.employerId}
-          onMessageSent={onMessageSent}
-        />
+        <>
+          <JobOfferMessageSender
+            employerId={jobOffer.employerId}
+            onMessageSent={onMessageSent}
+          />
+
+          <Button mode={'contained-tonal'} onPress={onEmployerInfoClick}>
+            {i18n.t('jobOffer.info.employerInfo')}
+          </Button>
+        </>
       )}
     </View>
   );

--- a/front/src/components/jobOffers/JobOfferContent.tsx
+++ b/front/src/components/jobOffers/JobOfferContent.tsx
@@ -4,8 +4,10 @@ import { Alert, StyleSheet, View } from 'react-native';
 import { Button, Text, useTheme } from 'react-native-paper';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
+import { JobOfferMessageSender } from '@/components/jobOffers/JobOfferMessageSender';
 import JobOfferStatusBadge from '@/components/jobOffers/JobOfferStatusBadge';
 import { JobOffer, JobOfferStatus } from '@/models/entities/jobOffer';
+import { Message } from '@/models/entities/message';
 import { usePostApplyJobOfferMutation } from '@/store/api/jobOfferApiSlice';
 import i18n from '@/utils/i18n';
 
@@ -44,13 +46,21 @@ type JobOfferContentProps = {
    * The job offer to display.
    */
   jobOffer: JobOffer;
+
+  /**
+   * The function to call when a message has been sent.
+   */
+  onMessageSent?: (message: Message) => void;
 };
 
 /**
  * Displays the details about a job offer.
  * @constructor
  */
-const JobOfferContent: FC<JobOfferContentProps> = ({ jobOffer }) => {
+const JobOfferContent: FC<JobOfferContentProps> = ({
+  jobOffer,
+  onMessageSent,
+}) => {
   // API calls
   const [applyToJobOffer] = usePostApplyJobOfferMutation();
 
@@ -130,6 +140,13 @@ const JobOfferContent: FC<JobOfferContentProps> = ({ jobOffer }) => {
             {i18n.t('jobOffer.apply.apply')}
           </Button>
         </View>
+      )}
+
+      {jobOffer.status === JobOfferStatus.ACCEPTED && (
+        <JobOfferMessageSender
+          employerId={jobOffer.employerId}
+          onMessageSent={onMessageSent}
+        />
       )}
     </View>
   );

--- a/front/src/components/jobOffers/JobOfferMessageSender.tsx
+++ b/front/src/components/jobOffers/JobOfferMessageSender.tsx
@@ -1,0 +1,83 @@
+import { FC, useCallback, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button, TextInput } from 'react-native-paper';
+
+import { CreateEmployerMessageDto } from '@/models/dtos/employer/createEmployerMessageDto';
+import { Message } from '@/models/entities/message';
+import { usePostEmployerMessageMutation } from '@/store/api/employerApiSlice';
+import i18n from '@/utils/i18n';
+
+/**
+ * The styles for the JobOfferMessageSender component.
+ */
+const styles = StyleSheet.create({
+  container: {
+    gap: 10,
+  },
+  textInput: {
+    flex: 1,
+  },
+});
+
+/**
+ * The props for the JobOfferMessageSender component.
+ */
+type JobOfferMessageSenderProps = {
+  /**
+   * The employer ID to send the message to.
+   */
+  employerId: string;
+
+  /**
+   * The function to call when a message has been sent.
+   */
+  onMessageSent?: (message: Message) => void;
+};
+
+/**
+ * Form for sending a message to the employer that posted the job offer.
+ * @constructor
+ */
+export const JobOfferMessageSender: FC<JobOfferMessageSenderProps> = ({
+  employerId,
+  onMessageSent,
+}) => {
+  // Hooks
+  const [content, setContent] = useState('');
+
+  // API calls
+  const [postMessage] = usePostEmployerMessageMutation();
+
+  // Callbacks
+  const handleSendMessage = useCallback(() => {
+    const message: CreateEmployerMessageDto = {
+      employerId,
+      content,
+    };
+
+    postMessage(message).then((res) => {
+      if ('error' in res) {
+        return;
+      }
+
+      setContent('');
+      onMessageSent?.(res.data);
+    });
+  }, [content, employerId, onMessageSent, postMessage]);
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.textInput}
+        placeholder={i18n.t('messaging.info.textInputPlaceholder')}
+        value={content}
+        onChangeText={setContent}
+        mode={'outlined'}
+      />
+
+      <Button mode={'contained'} onPress={handleSendMessage}>
+        {i18n.t('common.submit')}
+      </Button>
+    </View>
+  );
+};

--- a/front/src/components/messaging/MessageChannelContent.tsx
+++ b/front/src/components/messaging/MessageChannelContent.tsx
@@ -33,7 +33,7 @@ type MessageChannelContentProps = {
 };
 
 /**
- * Displays the the conversation of a message channel.
+ * Displays the conversation of a message channel.
  * @constructor
  */
 const MessageChannelContent: FC<MessageChannelContentProps> = ({

--- a/front/src/components/messaging/MessageChannelList.tsx
+++ b/front/src/components/messaging/MessageChannelList.tsx
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
 
 type MessageChannelListProps = {
   /**
-   * The function to call when an a message channel is pressed.
+   * The function to call when a message channel is pressed.
    */
   onItemPress?: (messageChannel: MessageChannel) => void;
 

--- a/front/src/components/messaging/MessageTextInput.tsx
+++ b/front/src/components/messaging/MessageTextInput.tsx
@@ -30,9 +30,11 @@ type MessageTextInputProps = {
 };
 
 const MessageTextInput: FC<MessageTextInputProps> = ({ messageChannelId }) => {
+  // Hooks
   const theme = useTheme();
-  // API calls
   const [content, setContent] = useState('');
+
+  // API calls
   const [postMessage] = usePostMessageMutation();
 
   // Callbacks
@@ -40,6 +42,7 @@ const MessageTextInput: FC<MessageTextInputProps> = ({ messageChannelId }) => {
     postMessage({ id: messageChannelId, content });
     setContent('');
   };
+
   return (
     <View style={styles.container}>
       <TextInput

--- a/front/src/models/dtos/employer/createEmployerEvaluationDto.ts
+++ b/front/src/models/dtos/employer/createEmployerEvaluationDto.ts
@@ -3,7 +3,7 @@ import { EmployerEvaluation } from '@/models/entities/employerEvaluation';
 /**
  * DTO for creating a new employer evaluation.
  */
-export type EmployerEvaluationDto = {
+export type CreateEmployerEvaluationDto = {
   /**
    * The id of the employer.
    */

--- a/front/src/models/dtos/employer/createEmployerMessageDto.ts
+++ b/front/src/models/dtos/employer/createEmployerMessageDto.ts
@@ -1,0 +1,14 @@
+/**
+ * DTO for creating a new message to an employer.
+ */
+export type CreateEmployerMessageDto = {
+  /**
+   * The employer id.
+   */
+  employerId: string;
+
+  /**
+   * The content of the message.
+   */
+  content: string;
+};

--- a/front/src/models/entities/jobOffer.ts
+++ b/front/src/models/entities/jobOffer.ts
@@ -48,4 +48,9 @@ export type JobOffer = {
    * The status of the job offer.
    */
   status: JobOfferStatus;
+
+  /**
+   * The ID of the employer that created the job offer.
+   */
+  employerId: string;
 };

--- a/front/src/pages/employer/EmployerEvaluationPage.tsx
+++ b/front/src/pages/employer/EmployerEvaluationPage.tsx
@@ -7,7 +7,7 @@ import { Button } from 'react-native-paper';
 import EmployerEvaluationForm, {
   EmployerEvaluationFormData,
 } from '@/components/employer/EmployerEvaluationForm';
-import { EmployerEvaluationDto } from '@/models/dtos/employer/EmployerEvaluationDto';
+import { CreateEmployerEvaluationDto } from '@/models/dtos/employer/createEmployerEvaluationDto';
 import {
   useGetEmployerQuery,
   usePostEmployerEvaluationMutation,
@@ -69,7 +69,7 @@ const EmployerEvaluationPage: FC<EmployerEvaluationPageProps> = ({
 
   // Callbacks
   const handleSubmitEvaluation = useCallback(() => {
-    const newEvaluation: EmployerEvaluationDto = {
+    const newEvaluation: CreateEmployerEvaluationDto = {
       id: employerId,
       evaluation: {
         score: formData.score,

--- a/front/src/pages/employer/EmployerEvaluationPage.tsx
+++ b/front/src/pages/employer/EmployerEvaluationPage.tsx
@@ -1,18 +1,13 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { FC, useCallback, useState } from 'react';
+import { FC, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
-import EmployerEvaluationForm, {
-  EmployerEvaluationFormData,
-} from '@/components/employer/EmployerEvaluationForm';
-import { CreateEmployerEvaluationDto } from '@/models/dtos/employer/createEmployerEvaluationDto';
+import EmployerEvaluationContent from '@/components/employer/EmployerEvaluationContent';
 import {
+  useGetEmployerEvaluationQuery,
   useGetEmployerQuery,
-  usePostEmployerEvaluationMutation,
 } from '@/store/api/employerApiSlice';
-import i18n from '@/utils/i18n';
 
 import { MessagingStackParamList } from '../messaging/MessagingNav';
 
@@ -46,65 +41,44 @@ export type EmployerEvaluationPageParams = {
 };
 
 /**
- * Displays the page for a single message channel.
+ * Displays the page for an employer.
  * @constructor
  */
-const EmployerEvaluationPage: FC<EmployerEvaluationPageProps> = ({
-  route,
-  navigation,
-}) => {
+const EmployerEvaluationPage: FC<EmployerEvaluationPageProps> = ({ route }) => {
+  // Route params
   const { id: employerId } = route.params;
 
   // API calls
   const { data: employer, refetch: refetchEmployer } =
     useGetEmployerQuery(employerId);
 
-  const [postEmployerEvaluation] = usePostEmployerEvaluationMutation();
-
-  // State
-  const [formData, setFormData] = useState<EmployerEvaluationFormData>({
-    score: 1,
-    review: '',
-  });
-
-  // Callbacks
-  const handleSubmitEvaluation = useCallback(() => {
-    const newEvaluation: CreateEmployerEvaluationDto = {
-      id: employerId,
-      evaluation: {
-        score: formData.score,
-        review: formData.review,
-      },
-    };
-
-    postEmployerEvaluation(newEvaluation)
-      .unwrap()
-      .then(() => {
-        navigation.goBack();
-      });
-  }, [employerId, formData, navigation, postEmployerEvaluation]);
+  const {
+    data: employerEvaluation,
+    refetch: refetchEmployerEvaluation,
+    isError: hasEmployerEvaluationErrored,
+  } = useGetEmployerEvaluationQuery(employerId);
 
   // Fetch data from the API when the page is focused
   useFocusEffect(
     useCallback(() => {
       refetchEmployer();
-    }, [refetchEmployer]),
+      refetchEmployerEvaluation();
+    }, [refetchEmployer, refetchEmployerEvaluation]),
   );
 
-  if (employer === undefined) {
+  if (
+    employer === undefined ||
+    (employerEvaluation === undefined && !hasEmployerEvaluationErrored)
+  ) {
     return null;
   }
 
   return (
     <View style={styles.contentContainer}>
-      <EmployerEvaluationForm
+      <EmployerEvaluationContent
         employer={employer}
-        formData={formData}
-        onFormDataUpdate={setFormData}
+        employerEvaluation={employerEvaluation}
       />
-      <Button mode='contained-tonal' onPress={handleSubmitEvaluation}>
-        {i18n.t('employer.sendEvaluation')}
-      </Button>
     </View>
   );
 };

--- a/front/src/pages/jobOffer/JobOfferNav.tsx
+++ b/front/src/pages/jobOffer/JobOfferNav.tsx
@@ -1,6 +1,9 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import PaperNavigationBar from '@/components/utils/PaperNavigationBar';
+import EmployerEvaluationPage, {
+  EmployerEvaluationPageParams,
+} from '@/pages/employer/EmployerEvaluationPage';
 import MessageChannelPage, {
   MessageChannelPageParams,
 } from '@/pages/messaging/MessageChannelPage';
@@ -17,6 +20,7 @@ export type JobOfferStackParamList = {
   JobOfferList: undefined;
   JobOffer: JobOfferPageParams;
   JobOfferApplication: undefined;
+  OfferEmployerEvaluation: EmployerEvaluationPageParams;
 };
 
 const JobOfferStack = createNativeStackNavigator<JobOfferStackParamList>();
@@ -46,6 +50,14 @@ const JobOffersNav = () => {
         component={MessageChannelPage}
         options={{
           headerTitle: `${i18n.t('messaging.info.messageChannel')}`,
+          headerShown: true,
+        }}
+      />
+      <JobOfferStack.Screen
+        name='OfferEmployerEvaluation'
+        component={EmployerEvaluationPage}
+        options={{
+          headerTitle: `${i18n.t('employer.evaluation')}`,
           headerShown: true,
         }}
       />

--- a/front/src/pages/jobOffer/JobOfferNav.tsx
+++ b/front/src/pages/jobOffer/JobOfferNav.tsx
@@ -1,6 +1,9 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import PaperNavigationBar from '@/components/utils/PaperNavigationBar';
+import MessageChannelPage, {
+  MessageChannelPageParams,
+} from '@/pages/messaging/MessageChannelPage';
 import i18n from '@/utils/i18n';
 
 import JobOfferListPage from './JobOfferListPage';
@@ -10,6 +13,7 @@ import JobOfferPage, { JobOfferPageParams } from './JobOfferPage';
  * The parameter list for the JobOffersNav navigator.
  */
 export type JobOfferStackParamList = {
+  EmployerMessageChannel: MessageChannelPageParams;
   JobOfferList: undefined;
   JobOffer: JobOfferPageParams;
   JobOfferApplication: undefined;
@@ -36,6 +40,14 @@ const JobOffersNav = () => {
         name='JobOffer'
         component={JobOfferPage}
         options={{ headerTitle: `${i18n.t('jobOffer.info.jobOffer')}` }}
+      />
+      <JobOfferStack.Screen
+        name='EmployerMessageChannel'
+        component={MessageChannelPage}
+        options={{
+          headerTitle: `${i18n.t('messaging.info.messageChannel')}`,
+          headerShown: true,
+        }}
       />
     </JobOfferStack.Navigator>
   );

--- a/front/src/pages/jobOffer/JobOfferPage.tsx
+++ b/front/src/pages/jobOffer/JobOfferPage.tsx
@@ -1,8 +1,9 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { FC } from 'react';
+import { FC, useCallback } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 
 import JobOfferContent from '@/components/jobOffers/JobOfferContent';
+import { Message } from '@/models/entities/message';
 import { useGetJobOfferQuery } from '@/store/api/jobOfferApiSlice';
 
 import { JobOfferStackParamList } from './JobOfferNav';
@@ -43,12 +44,20 @@ export type JobOfferPageParams = {
  * Displays the page for a single job offer.
  * @constructor
  */
-const JobOfferPage: FC<JobOfferPageProps> = ({ route }) => {
+const JobOfferPage: FC<JobOfferPageProps> = ({ navigation, route }) => {
   // Route params
   const { id: jobOfferId } = route.params;
 
   // API calls
   const { data: jobOffer } = useGetJobOfferQuery(jobOfferId);
+
+  // Callbacks
+  const handleMessageSent = useCallback(
+    (message: Message) => {
+      navigation.navigate('EmployerMessageChannel', { id: message.channelId });
+    },
+    [navigation],
+  );
 
   if (jobOffer === undefined) {
     return null;
@@ -59,7 +68,7 @@ const JobOfferPage: FC<JobOfferPageProps> = ({ route }) => {
       style={styles.container}
       contentContainerStyle={styles.contentContainer}
     >
-      <JobOfferContent jobOffer={jobOffer} />
+      <JobOfferContent jobOffer={jobOffer} onMessageSent={handleMessageSent} />
     </ScrollView>
   );
 };

--- a/front/src/pages/jobOffer/JobOfferPage.tsx
+++ b/front/src/pages/jobOffer/JobOfferPage.tsx
@@ -59,6 +59,12 @@ const JobOfferPage: FC<JobOfferPageProps> = ({ navigation, route }) => {
     [navigation],
   );
 
+  const handleEmployerInfoClick = useCallback(() => {
+    navigation.navigate('OfferEmployerEvaluation', {
+      id: jobOffer?.employerId,
+    });
+  }, [jobOffer, navigation]);
+
   if (jobOffer === undefined) {
     return null;
   }
@@ -68,7 +74,11 @@ const JobOfferPage: FC<JobOfferPageProps> = ({ navigation, route }) => {
       style={styles.container}
       contentContainerStyle={styles.contentContainer}
     >
-      <JobOfferContent jobOffer={jobOffer} onMessageSent={handleMessageSent} />
+      <JobOfferContent
+        jobOffer={jobOffer}
+        onMessageSent={handleMessageSent}
+        onEmployerInfoClick={handleEmployerInfoClick}
+      />
     </ScrollView>
   );
 };

--- a/front/src/pages/login/FirstLoginPage.tsx
+++ b/front/src/pages/login/FirstLoginPage.tsx
@@ -69,6 +69,7 @@ const FirstLoginPage: FC = () => {
 
     putProfile(newProfile);
   }, [formData, putProfile]);
+
   return (
     <ScrollView
       style={styles.container}

--- a/front/src/pages/messaging/MessageChannelPage.tsx
+++ b/front/src/pages/messaging/MessageChannelPage.tsx
@@ -2,6 +2,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { FC, useCallback, useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { Appbar } from 'react-native-paper';
 
 import MessageChannelContent from '@/components/messaging/MessageChannelContent';
 import {
@@ -63,12 +64,22 @@ const MessageChannelPage: FC<MessageChannelPageProps> = ({
     }, [refetchMessages]),
   );
 
-  // Set the header title
+  // Callbacks
+  const handleInfoPress = useCallback(() => {
+    navigation.navigate('EmployerEvaluation', {
+      id: messageChannel.employer.id,
+    });
+  }, [messageChannel, navigation]);
+
+  // Set the header title and button
   useEffect(() => {
     navigation.setOptions({
       headerTitle: `${messageChannel?.employer.firstName} ${messageChannel?.employer.lastName}`,
+      headerRight: () => (
+        <Appbar.Action icon={'information-outline'} onPress={handleInfoPress} />
+      ),
     });
-  }, [messageChannel, navigation]);
+  }, [handleInfoPress, messageChannel, navigation]);
 
   if (messageChannel === undefined || messages === undefined) {
     return null;

--- a/front/src/pages/messaging/MessagingNav.tsx
+++ b/front/src/pages/messaging/MessagingNav.tsx
@@ -15,10 +15,10 @@ import MessageTabBarNav from './MessageTabBarNav';
  * The parameter list for the MessagingNav navigator.
  */
 export type MessagingStackParamList = {
+  EmployerEvaluation: EmployerEvaluationPageParams;
   MessageChannelList: undefined;
   MessageChannel: MessageChannelPageParams;
   MessageTabBar: undefined;
-  EmployerEvaluation: EmployerEvaluationPageParams;
 };
 
 const MessagingStack = createNativeStackNavigator<MessagingStackParamList>();

--- a/front/src/store/api/apiSlice.ts
+++ b/front/src/store/api/apiSlice.ts
@@ -24,6 +24,7 @@ export const apiSlice = createApi({
   tagTypes: [
     'Availabilities',
     'Employer',
+    'EmployerEvaluation',
     'Evaluations',
     'Experiences',
     'JobCategories',

--- a/front/src/store/api/employerApiSlice.ts
+++ b/front/src/store/api/employerApiSlice.ts
@@ -23,7 +23,24 @@ export const extendedApiSlice = apiSlice.injectEndpoints({
         method: 'POST',
         body: body.evaluation,
       }),
-      invalidatesTags: [{ type: 'Employer', id: 'LIST' }],
+      invalidatesTags: (_result, _error, { id }) => [
+        { type: 'EmployerEvaluation', id },
+      ],
+    }),
+    getEmployerEvaluation: builder.query<EmployerEvaluation, string>({
+      query: (id) => `employers/${id}/evaluations`,
+      providesTags: (_result, _error, id) => [
+        { type: 'EmployerEvaluation', id },
+      ],
+    }),
+    deleteEmployerEvaluation: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `employers/${id}/evaluations`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (_result, _error, id) => [
+        { type: 'EmployerEvaluation', id },
+      ],
     }),
     postEmployerMessage: builder.mutation<Message, CreateEmployerMessageDto>({
       query: (body) => ({
@@ -39,5 +56,7 @@ export const extendedApiSlice = apiSlice.injectEndpoints({
 export const {
   useGetEmployerQuery,
   usePostEmployerEvaluationMutation,
+  useGetEmployerEvaluationQuery,
+  useDeleteEmployerEvaluationMutation,
   usePostEmployerMessageMutation,
 } = extendedApiSlice;

--- a/front/src/store/api/employerApiSlice.ts
+++ b/front/src/store/api/employerApiSlice.ts
@@ -1,6 +1,8 @@
-import { EmployerEvaluationDto } from '@/models/dtos/employer/EmployerEvaluationDto';
+import { CreateEmployerEvaluationDto } from '@/models/dtos/employer/createEmployerEvaluationDto';
+import { CreateEmployerMessageDto } from '@/models/dtos/employer/createEmployerMessageDto';
 import { Employer } from '@/models/entities/employer';
 import { EmployerEvaluation } from '@/models/entities/employerEvaluation';
+import { Message } from '@/models/entities/message';
 import { apiSlice } from '@/store/api/apiSlice';
 
 /**
@@ -14,7 +16,7 @@ export const extendedApiSlice = apiSlice.injectEndpoints({
     }),
     postEmployerEvaluation: builder.mutation<
       EmployerEvaluation,
-      EmployerEvaluationDto
+      CreateEmployerEvaluationDto
     >({
       query: (body) => ({
         url: `employers/${body.id}/evaluations`,
@@ -23,8 +25,19 @@ export const extendedApiSlice = apiSlice.injectEndpoints({
       }),
       invalidatesTags: [{ type: 'Employer', id: 'LIST' }],
     }),
+    postEmployerMessage: builder.mutation<Message, CreateEmployerMessageDto>({
+      query: (body) => ({
+        url: `employers/${body.employerId}/messaging`,
+        method: 'POST',
+        body: { content: body.content },
+      }),
+      invalidatesTags: [{ type: 'Message', id: 'LIST' }],
+    }),
   }),
 });
 
-export const { useGetEmployerQuery, usePostEmployerEvaluationMutation } =
-  extendedApiSlice;
+export const {
+  useGetEmployerQuery,
+  usePostEmployerEvaluationMutation,
+  usePostEmployerMessageMutation,
+} = extendedApiSlice;


### PR DESCRIPTION
This adds a form to send a message to the employer that created a job offer whose the season worker has been accepted.

This also reworks the employer evaluation screen to fetch the current evaluation instead of having a default form, add a button to delete the evaluation, and make this view available in the message view and job offer view when the offer has been accepted.