### PR TITLE
feat: improve infrastructure security

### DIFF
--- a/.github/workflows/flow_backend_build_push.yml
+++ b/.github/workflows/flow_backend_build_push.yml
@@ -33,6 +33,9 @@ jobs:
       packages: write
       contents: read
     steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v3
+
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@v3
 
@@ -53,6 +56,7 @@ jobs:
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
+      id: build_and_push
       with:
         push: ${{ inputs.push-image }}
         tags: ${{ steps.meta.outputs.tags }}
@@ -61,3 +65,16 @@ jobs:
         cache-to: type=gha,mode=max
         context: "{{ defaultContext }}:${{ inputs.service-build-context-path }}"
         build-args: SERVICE_NAME=${{ inputs.service-name }}
+
+    - name: Sign image with Cosign
+      run: |
+        images=""
+        for tag in ${TAGS}; do
+          images+="${tag}@${DIGEST} "
+        done
+        cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${images}
+      env:
+        TAGS: ${{ steps.meta.outputs.tags }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        DIGEST: ${{ steps.build_and_push.outputs.digest }}

--- a/.github/workflows/flow_backend_build_push.yml
+++ b/.github/workflows/flow_backend_build_push.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3
+      if: ${{ inputs.push-image }}
 
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@v3
@@ -67,6 +68,7 @@ jobs:
         build-args: SERVICE_NAME=${{ inputs.service-name }}
 
     - name: Sign image with Cosign
+      if: ${{ inputs.push-image }}
       run: |
         images=""
         for tag in ${TAGS}; do

--- a/.github/workflows/on_push_pr_main.yml
+++ b/.github/workflows/on_push_pr_main.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/on_push_pr_main.yml
+++ b/.github/workflows/on_push_pr_main.yml
@@ -101,6 +101,7 @@ jobs:
     name: Build & push Docker image of the "${{ matrix.service }}" service
     needs: lint_backend
     uses: ./.github/workflows/flow_backend_build_push.yml
+    secrets: inherit
     strategy:
       matrix:
         service: [api_gateway, jobs, messaging, employer, notification, profile, recommendation]

--- a/.github/workflows/on_semver_tag.yml
+++ b/.github/workflows/on_semver_tag.yml
@@ -9,6 +9,7 @@ jobs:
   build_push_backend:
     name: Build & push Docker image of the "${{ matrix.service }}" service
     uses: ./.github/workflows/flow_backend_build_push.yml
+    secrets: inherit
     strategy:
       matrix:
         service: [api_gateway, jobs, messaging, employer, notification, profile, recommendation]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,8 +16,10 @@ RUN --mount=type=cache,target=/root/.gradle ./gradlew clean bootJar
 # Run stage
 FROM amazoncorretto:17-alpine AS run
 ARG SERVICE_NAME
+RUN addgroup -S linkedout && adduser -u 1001 -S linkedout -G linkedout
 WORKDIR /app
 
 COPY --from=build /app/$SERVICE_NAME/build/libs/$SERVICE_NAME.jar ./app.jar
 
+USER 1001
 ENTRYPOINT ["java", "-jar", "./app.jar"]

--- a/kube/base/api_gateway/deployment.yml
+++ b/kube/base/api_gateway/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-apigw
         app.kubernetes.io/part-of: linkedout
+        network-group: api-gateway
     spec:
       containers:
       - name: linkedout-apigw

--- a/kube/base/api_gateway/deployment.yml
+++ b/kube/base/api_gateway/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/api_gateway
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 9090
             name: api

--- a/kube/base/employer/deployment.yml
+++ b/kube/base/employer/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/employer
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 8083
             name: api

--- a/kube/base/employer/deployment.yml
+++ b/kube/base/employer/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-employer
         app.kubernetes.io/part-of: linkedout
+        network-group: microservices
     spec:
       containers:
       - name: linkedout-employer

--- a/kube/base/jobs/deployment.yml
+++ b/kube/base/jobs/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/jobs
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 8081
             name: api

--- a/kube/base/jobs/deployment.yml
+++ b/kube/base/jobs/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-jobs
         app.kubernetes.io/part-of: linkedout
+        network-group: microservices
     spec:
       containers:
       - name: linkedout-jobs

--- a/kube/base/messaging/deployment.yml
+++ b/kube/base/messaging/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/messaging
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 8082
             name: api

--- a/kube/base/messaging/deployment.yml
+++ b/kube/base/messaging/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-messaging
         app.kubernetes.io/part-of: linkedout
+        network-group: microservices
     spec:
       containers:
       - name: linkedout-messaging

--- a/kube/base/notification/deployment.yml
+++ b/kube/base/notification/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-notification
         app.kubernetes.io/part-of: linkedout
+        network-group: microservices
     spec:
       containers:
       - name: linkedout-notification

--- a/kube/base/notification/deployment.yml
+++ b/kube/base/notification/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/notification
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 8084
             name: api

--- a/kube/base/profile/deployment.yml
+++ b/kube/base/profile/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/profile
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 8085
             name: api

--- a/kube/base/profile/deployment.yml
+++ b/kube/base/profile/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-profile
         app.kubernetes.io/part-of: linkedout
+        network-group: microservices
     spec:
       containers:
       - name: linkedout-profile

--- a/kube/base/recommendation/deployment.yml
+++ b/kube/base/recommendation/deployment.yml
@@ -20,6 +20,13 @@ spec:
         image: ghcr.io/thomas-mauran/linkedout/recommendation
         imagePullPolicy: Always
         env: []
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         ports:
           - containerPort: 8086
             name: api

--- a/kube/base/recommendation/deployment.yml
+++ b/kube/base/recommendation/deployment.yml
@@ -14,6 +14,7 @@ spec:
       labels:
         app.kubernetes.io/name: linkedout-recommendation
         app.kubernetes.io/part-of: linkedout
+        network-group: microservices
     spec:
       containers:
       - name: linkedout-recommendation

--- a/kube/prod/add-resource-limits.patch.yml
+++ b/kube/prod/add-resource-limits.patch.yml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    requests:
+      memory: "1Gi"
+      cpu: "0.5"
+    limits:
+      memory: "2Gi"
+      cpu: "1"

--- a/kube/prod/kustomization.yml
+++ b/kube/prod/kustomization.yml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: linkedout
 resources:
 - ../base
+- kyverno-policy.yml
 
 patches:
 - target:

--- a/kube/prod/kustomization.yml
+++ b/kube/prod/kustomization.yml
@@ -5,13 +5,9 @@ namespace: linkedout
 resources:
 - ../base
 - kyverno-policy.yml
+- network-policies.yml
 
 patches:
-- target:
-    group: networking.k8s.io
-    version: v1
-    kind: Ingress
-  path: api_gateway/configure-ingress.patch.yml
 - target:
     group: apps
     version: v1
@@ -22,6 +18,11 @@ patches:
     version: v1
     kind: Deployment
   path: add-resource-limits.patch.yml
+- target:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+  path: api_gateway/configure-ingress.patch.yml
 - target:
     group: apps
     version: v1

--- a/kube/prod/kustomization.yml
+++ b/kube/prod/kustomization.yml
@@ -21,6 +21,11 @@ patches:
     group: apps
     version: v1
     kind: Deployment
+  path: add-resource-limits.patch.yml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
     name: linkedout-employer
   path: employer/add-postgres.patch.yml
 - target:

--- a/kube/prod/kyverno-policy.yml
+++ b/kube/prod/kyverno-policy.yml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: check-linkedout-image-signature
+spec:
+  validationFailureAction: Enforce
+  background: false
+  webhookTimeoutSeconds: 30
+  failurePolicy: Fail
+  rules:
+    - name: check-image
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        - imageReferences:
+            - "ghcr.io/thomas-mauran/linkedout/*"
+          attestors:
+            - count: 1
+              entries:
+                - keys:
+                    publicKeys: |-
+                      -----BEGIN PUBLIC KEY-----
+                      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaFU86MNnoiHTLXkBrgnPO18R5gpo
+                      cMic199RKzUa6YftDcDCEovrR0nyzfGp3pKcr4nhjwi3qNRQRHPz76EaWg==
+                      -----END PUBLIC KEY-----

--- a/kube/prod/network-policies.yml
+++ b/kube/prod/network-policies.yml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: microservices
+spec:
+  podSelector:
+    matchLabels:
+      network-group: microservices
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: nats
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: postgresql
+      - podSelector:
+          matchLabels:
+            helm.neo4j.com/neo4j.name: linkedout
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/name: minio
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: coredns-egress
+spec:
+  podSelector:
+    matchLabels:
+      network-group: microservices
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        podSelector:
+          matchLabels:
+            k8s-app: kube-dns
+      ports:
+      - protocol: UDP
+        port: 53


### PR DESCRIPTION
This improves the overall security of the project by doing the following:
- Sign the container images that are pushed to GHCR via the CI
- Add an image signature verification policy in Kubernetes
- Run the microservices as a non-root user in the containers
- Drop privileges in the Kubernetes deployments
- Configure resource limits for the containers in Kubernetes
- Configure network policies in Kubernetes

## Other changes

The `dorny/paths-filter` action in the CI has been updated to `v3`.